### PR TITLE
bugfixes for printing

### DIFF
--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -2,7 +2,5 @@ module main
 
 proc main start
     var text = "There"
-    var some_text = "Whatever"
-    i64 = lf; var x = f"{some_text}.{i64}"
-    print(f"Hello {text}!", f"It's a beautiful world! {x}")
+    print(f"Hello {text}!", "It's a beautiful world!", lf)
 end

--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -1,6 +1,6 @@
 module main
 
 proc main start
-    var x = "World"
-    print(f"Hello, {x}", "!\n")
+    var text = "There"
+    print(f"Hello {text}!", "It's a beautiful world!", "\n")
 end

--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -2,5 +2,7 @@ module main
 
 proc main start
     var text = "There"
-    print(f"Hello {text}!", "It's a beautiful world!", "\n")
+    var some_text = "Whatever"
+    i64 = lf; var x = f"{some_text}.{i64}"
+    print(f"Hello {text}!", f"It's a beautiful world! {x}")
 end

--- a/src/functions.c
+++ b/src/functions.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <string.h>
 
 #include "functions.h"
@@ -26,6 +27,7 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
                 const char var[4] = { ((i % 100) / 10) + '0', (i % 10) + '0', '\0' };
                 const RT_Data_t data = *RT_VarTable_getref(var);
                 if (RT_Data_isnull(data)) continue;
+                if (i > 0) printf(" ");
                 bytes += RT_Data_print(data);
             }
             ret = RT_Data_i64(bytes);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -498,7 +498,9 @@ RT_Data_t *rt_Expression_eval(const AST_Expression_t *expr)
         case TOKOP_INDEXING:
         case TOKOP_TERNARY_COND:
         case TOKOP_FNARGS_INDEXING: break;
-        case TOKOP_NOP: break;
+        case TOKOP_NOP:
+            RT_VarTable_acc_setval(*lhs);
+            break;
         /* stuff that doesn't form an operation */
         default: io_errndie("rt_Expression_eval: invalid operation '%s'", lex_get_tokcode(expr->op));
     }

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -177,11 +177,12 @@ char *RT_Data_interp_str_parse(const char *str_)
         sprintf(ret +p, "%s", val);
         free(val);
         val = NULL;
-        p += sz;
-        i += idflen -1;
+        p += sz -1;
+        i += idflen +1;
     }
     free(str);
     str = NULL;
+    ret[p] = 0;
     return ret;
 }
 

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -2,7 +2,7 @@
 #define RT_DATA_C_H
 
 #include <ctype.h>
-#include "inttypes.h"
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/runtime/data/string.c.h
+++ b/src/runtime/data/string.c.h
@@ -18,10 +18,15 @@ RT_DataStr_t *RT_DataStr_init(const char *s)
     RT_DataStr_t *str = (RT_DataStr_t*) malloc(sizeof(RT_DataStr_t));
     if (!str) io_errndie("RT_DataStr_init:" ERR_MSG_MALLOCFAIL);
     str->length = !s ? 0 : strlen(s);
-    str->capacity = !s ? 0 : str->length +1;
-    str->var = !s ? NULL : (char*) malloc(str->capacity * sizeof(char) +1);
-    if (str->var) strncpy(str->var, s, str->length);
-    str->var[str->length] = 0;
+    str->capacity = !s ? 0 : (str->length +1);
+    if (s) {
+        str->var = (char*) malloc(str->capacity * sizeof(char) +1);
+        if (!str->var) io_errndie("RT_DataStr_init:" ERR_MSG_MALLOCFAIL);
+        strncpy(str->var, s, str->length);
+        str->var[str->length] = 0;
+    } else {
+        str->var = NULL;
+    }
     /* rc is kept at 0 unless the runtime assigns
        a variable to the data */
     str->rc = 0;


### PR DESCRIPTION
- fixed a warning: stringop-truncation
- bug fix: format strings would get null terminated in the wrong place
- added reserved variables
- bug fix: evaluated expr was not set to acc which resulted in undefined behaviours
