### PR TITLE
major bug fixes to ref counting

### DIFF
--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -8,9 +8,10 @@ proc test start
             "It's a beautiful world!", lf)
         print(f"Printed: {bytes} Bytes", lf, lf)
     end
+    return 100
 end
 
 proc main start
     var ret = test("Times", [1, 2, 3, 4, 5])
-    print(ret, lf)
+    print("Return val:", ret, lf)
 end

--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -1,14 +1,16 @@
 module main
 
 proc test start
-    for i from 0 to 5 do
-        var text = input("Enter you name: ", str)
-        var bytes = print(f"Hello {text}!", "It's a beautiful world!", lf)
-        return f"Printed: {bytes} Bytes"
+    var times = $1
+    for x in times do
+        var name = input(f"Enter name {x}: ", str)
+        var bytes = print(f"Hello {name}!",
+            "It's a beautiful world!", lf)
+        print(f"Printed: {bytes} Bytes", lf, lf)
     end
 end
 
 proc main start
-    var x = test()
-    print(x, lf)
+    var ret = test("Times", [1, 2, 3, 4, 5])
+    print(ret, lf)
 end

--- a/examples/helloworld.txt
+++ b/examples/helloworld.txt
@@ -1,9 +1,11 @@
 module main
 
 proc test start
-    var text = input("Enter you name: ", str)
-    var bytes = print(f"Hello {text}!", "It's a beautiful world!", lf)
-    return f"Printed: {bytes} Bytes"
+    for i from 0 to 5 do
+        var text = input("Enter you name: ", str)
+        var bytes = print(f"Hello {text}!", "It's a beautiful world!", lf)
+        return f"Printed: {bytes} Bytes"
+    end
 end
 
 proc main start

--- a/include/functions.h
+++ b/include/functions.h
@@ -6,6 +6,9 @@
 typedef enum {
     FN_PRINT,
     FN_INPUT,
+    FN_TYPE,
+    FN_LEN,
+    FN_REFCNT,
     FN_UNDEFINED,
 } FN_FunctionDescriptor_t;
 

--- a/include/runtime/data.h
+++ b/include/runtime/data.h
@@ -46,6 +46,7 @@ RT_Data_t RT_Data_interp_str(const char *str);
 RT_Data_t RT_Data_list(RT_DataList_t *lst);
 RT_Data_t RT_Data_any(void *ptr);
 RT_Data_t RT_Data_null(void);
+void RT_Data_copy(RT_Data_t *var);
 void RT_Data_destroy(RT_Data_t *var);
 
 bool RT_Data_isnull(const RT_Data_t var);

--- a/include/runtime/data/list.h
+++ b/include/runtime/data/list.h
@@ -1,6 +1,7 @@
 #ifndef RT_DATA_LIST_H
 #define RT_DATA_LIST_H
 
+#include <stddef.h>
 #include "runtime/data.h"
 
 struct RT_DataList_t {
@@ -12,6 +13,7 @@ struct RT_DataList_t {
 
 RT_DataList_t *RT_DataList_init();
 int64_t RT_DataList_length(const RT_DataList_t *lst);
+void RT_DataList_copy(RT_DataList_t *lst);
 void RT_DataList_destroy(RT_DataList_t **ptr);
 void RT_DataList_append(RT_DataList_t *lst, RT_Data_t var);
 void RT_DataList_set(RT_DataList_t *lst, int64_t idx, RT_Data_t var);

--- a/include/runtime/data/string.h
+++ b/include/runtime/data/string.h
@@ -1,6 +1,7 @@
 #ifndef RT_DATA_STRING_H
 #define RT_DATA_STRING_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include "runtime/data.h"
 
@@ -13,6 +14,7 @@ struct RT_DataStr_t {
 
 RT_DataStr_t *RT_DataStr_init(const char *s);
 int64_t RT_DataStr_length(const RT_DataStr_t *str);
+void RT_DataStr_copy(RT_DataStr_t *str);
 void RT_DataStr_destroy(RT_DataStr_t **ptr);
 void RT_DataStr_append(RT_DataStr_t *str, char ch);
 void RT_DataStr_set(RT_DataStr_t *str, int64_t idx, char var);

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -29,6 +29,8 @@ RT_Data_t *RT_VarTable_modf(RT_Data_t *dest, RT_Data_t src);
     on the returned data pointer, that'll take care of reference counts */
 RT_Data_t *RT_VarTable_getref(const char *varname);
 
+RT_Data_t *RT_VarTable_getref_tmpvar(int tmpvar);
+
 /** this is used to get the accumulator data and address */
 RT_VarTable_Acc_t *RT_VarTable_acc_get(void);
 

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -17,6 +17,20 @@ typedef struct {
     RT_Data_t *adr;
 } RT_VarTable_Acc_t;
 
+/* few globally defined variables */
+extern
+RT_Data_t RT_VarTable_rsv_lf,
+/* list of globally defined typename variables */
+          RT_VarTable_typeid_bul,
+          RT_VarTable_typeid_chr,
+          RT_VarTable_typeid_i64,
+          RT_VarTable_typeid_f64,
+          RT_VarTable_typeid_str,
+          RT_VarTable_typeid_interp_str,
+          RT_VarTable_typeid_lst,
+          RT_VarTable_typeid_any,
+          RT_VarTable_rsv_null;
+
 /** create a new variable in the current scope */
 void RT_VarTable_create(const char *varname, RT_Data_t value);
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -11,6 +11,7 @@
 #include "runtime/io.h"
 #include "runtime/data.h"
 #include "runtime/data/string.h"
+#include "runtime/data/list.h"
 #include "runtime/vartable.h"
 
 /*
@@ -29,6 +30,9 @@ FN_FunctionDescriptor_t FN_FunctionsList_getfn(const char *fname)
 {
     if (!strcmp(fname, "print")) return FN_PRINT;
     if (!strcmp(fname, "input")) return FN_INPUT;
+    if (!strcmp(fname, "type")) return FN_TYPE;
+    if (!strcmp(fname, "len")) return FN_LEN;
+    if (!strcmp(fname, "refcnt")) return FN_REFCNT;
     return FN_UNDEFINED;
 }
 
@@ -106,6 +110,72 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
                     "  values are: `%d`, `%d`, `%d`, `%d` or `%d` respectively",
                     RT_DATA_TYPE_BUL, RT_DATA_TYPE_CHR, RT_DATA_TYPE_I64, RT_DATA_TYPE_F64, RT_DATA_TYPE_STR);
                     break;
+            }
+            break;
+        }
+        case FN_TYPE: {
+            const char var[4] = "0";
+            const RT_Data_t data = *RT_VarTable_getref(var);
+            switch (data.type) {
+                case RT_DATA_TYPE_BUL:
+                    ret = RT_VarTable_typeid_bul;
+                    break;
+                case RT_DATA_TYPE_CHR:
+                    ret = RT_VarTable_typeid_chr;
+                    break;
+                case RT_DATA_TYPE_I64:
+                    ret = RT_VarTable_typeid_i64;
+                    break;
+                case RT_DATA_TYPE_F64:
+                    ret = RT_VarTable_typeid_f64;
+                    break;
+                case RT_DATA_TYPE_STR:
+                    ret = RT_VarTable_typeid_str;
+                    break;
+                case RT_DATA_TYPE_INTERP_STR:
+                    ret = RT_VarTable_typeid_interp_str;
+                    break;
+                case RT_DATA_TYPE_LST:
+                    ret = RT_VarTable_typeid_lst;
+                    break;
+                case RT_DATA_TYPE_ANY:
+                    ret = RT_Data_isnull(data) ?
+                        RT_VarTable_rsv_null : RT_VarTable_typeid_any;
+                    break;
+            }
+            break;
+        }
+        case FN_LEN: {
+            const char var[4] = "0";
+            const RT_Data_t data = *RT_VarTable_getref(var);
+            switch (data.type) {
+            case RT_DATA_TYPE_STR:
+            case RT_DATA_TYPE_INTERP_STR:
+                ret = RT_Data_i64(RT_DataStr_length(data.data.str));
+                break;
+            case RT_DATA_TYPE_LST:
+                ret = RT_Data_i64(RT_DataList_length(data.data.lst));
+                break;
+            default:
+                ret = RT_Data_i64(1);
+                break;
+            }
+            break;
+        }
+        case FN_REFCNT: {
+            const char var[4] = "0";
+            const RT_Data_t data = *RT_VarTable_getref(var);
+            switch (data.type) {
+            case RT_DATA_TYPE_STR:
+            case RT_DATA_TYPE_INTERP_STR:
+                ret = RT_Data_i64(data.data.str->rc);
+                break;
+            case RT_DATA_TYPE_LST:
+                ret = RT_Data_i64(data.data.lst->rc);
+                break;
+            default:
+                ret = RT_Data_i64(1);
+                break;
             }
             break;
         }

--- a/src/functions.c
+++ b/src/functions.c
@@ -158,7 +158,7 @@ void fn_input_i64(int64_t *val)
 {
     if (!val) io_errndie("fn_input_i64:" ERR_MSG_NULLPTR);
     char *str;
-    int len = fn_input_str(&str);
+    fn_input_str(&str);
     char *endptr;
     errno = 0;
     *val = (int64_t) strtoll(str, &endptr, 10);
@@ -171,7 +171,7 @@ void fn_input_f64(double *val)
 {
     if (!val) io_errndie("fn_input_f64:" ERR_MSG_NULLPTR);
     char *str;
-    int len = fn_input_str(&str);
+    fn_input_str(&str);
     char *endptr;
     errno = 0;
     *val = (double) strtod(str, &endptr);

--- a/src/lexer/match_keywords.c.h
+++ b/src/lexer/match_keywords.c.h
@@ -34,6 +34,7 @@ LexToken lex_match_keywords(FILE *f, char ch)
     if (!strcmp(lex_get_buffstr(), "continue"))  return LEXTOK_KWD_CONTINUE;
     if (!strcmp(lex_get_buffstr(), "for"))       return LEXTOK_KWD_FOR;
     if (!strcmp(lex_get_buffstr(), "from"))      return LEXTOK_KWD_FROM;
+    if (!strcmp(lex_get_buffstr(), "in"))        return LEXTOK_KWD_IN;
     if (!strcmp(lex_get_buffstr(), "to"))        return LEXTOK_KWD_TO;
     if (!strcmp(lex_get_buffstr(), "by"))        return LEXTOK_KWD_BY;
     if (!strcmp(lex_get_buffstr(), "do"))        return LEXTOK_KWD_DO;

--- a/src/parser.y
+++ b/src/parser.y
@@ -269,6 +269,7 @@ statements:
 statement:
     "pass" trm                                          { $$ = AST_Statement_empty(lex_line_no - $2); }
     | "return" expression trm                           { $$ = AST_Statement_return($2, lex_line_no - $3); }
+    | "return" trm                                      { $$ = AST_Statement_return(NULL, lex_line_no - $2); }
     | assignment trm                                    { $$ = AST_Statement_Assignment($1, lex_line_no - $2); }
     | compound_statement trm                            { $$ = AST_Statement_CompoundSt($1, lex_line_no - $2); }
     ;

--- a/src/parser.y
+++ b/src/parser.y
@@ -263,7 +263,7 @@ procedure:
 
 statements:
     %empty                                              { $$ = NULL; }
-    | statements statement                              { $$ = AST_Statements($1, $2); }
+    | statement statements                              { $$ = AST_Statements($2, $1); }
     ;
 
 statement:

--- a/src/parser.y
+++ b/src/parser.y
@@ -425,6 +425,11 @@ postfix_expression:
                                                         }
     | postfix_expression "[" nws expression "]"         { $$ = AST_Expression(TOKOP_INDEXING, $1, $4, NULL); }
     | "$" "[" nws expression "]"                        { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $4, NULL); }
+    | "$" "(" nws expression ")"                        { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $4, NULL); }
+    | "$" LEXTOK_DECINT_LITERAL                         { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL,
+                                                            AST_Expression_Literal(
+                                                                AST_Literal_i64($2)), NULL);
+                                                        }
     | postfix_expression "++"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "--"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "." identifier                 { $$ = AST_Expression($2, $1,

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -398,7 +398,12 @@ void rt_Expression_eval(const AST_Expression_t *expr)
         case TOKOP_FNCALL: break;
         case TOKOP_INDEXING:
         case TOKOP_TERNARY_COND:
-        case TOKOP_FNARGS_INDEXING: break;
+        case TOKOP_FNARGS_INDEXING:
+            if (!rhs || rhs->type != RT_DATA_TYPE_I64)
+                rt_throw("argument index should evaluate to an `i64`");
+            RT_VarTable_acc_setadr(
+                RT_VarTable_getref_tmpvar(rhs->data.i64));
+            break;
         case TOKOP_NOP:
             RT_VarTable_acc_setval(*lhs);
             break;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -175,7 +175,8 @@ void rt_WhileBlock_eval(const AST_WhileBlock_t *while_block)
     rt_Expression_eval(while_block->condition);
     bool cond = RT_Data_tobool(*RT_ACC_DATA);
     while (cond) {
-        rt_Statements_newscope_eval(while_block->statements);
+        bool return_ = rt_Statements_newscope_eval(while_block->statements);
+        if (return_) break;
     }
 }
 
@@ -415,7 +416,10 @@ void rt_Expression_eval(const AST_Expression_t *expr)
 
 void rt_Literal_eval(const AST_Literal_t *literal)
 {
-    if (!literal) return;
+    if (!literal) {
+        RT_VarTable_acc_setval(RT_Data_null());
+        return;
+    }
     switch (literal->type) {
         case DATA_TYPE_BUL:
             RT_VarTable_acc_setval(
@@ -455,14 +459,20 @@ void rt_Literal_eval(const AST_Literal_t *literal)
 
 void rt_Identifier_eval(const AST_Identifier_t *identifier)
 {
-    if (!identifier) return;
+    if (!identifier) {
+        RT_VarTable_acc_setval(RT_Data_null());
+        return;
+    }
     RT_VarTable_acc_setadr(
         RT_VarTable_getref(identifier->identifier_name));
 }
 
 void rt_CommaSepList_eval(const AST_CommaSepList_t *comma_list)
 {
-    if (!comma_list) return;
+    if (!comma_list) {
+        RT_VarTable_acc_setval(RT_Data_null());
+        return;
+    }
     const AST_CommaSepList_t *ptr = comma_list;
     RT_DataList_t *new_list = RT_DataList_init();
     while (ptr) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -74,7 +74,7 @@ bool rt_Statements_eval(const AST_Statements_t *code)
     if (!code) return false;
     const AST_Statements_t *ptr = code;
     while (ptr) {
-        bool return_ = rt_Statement_eval(code->statement);
+        bool return_ = rt_Statement_eval(ptr->statement);
         if (return_) return true;
         ptr = ptr->statements;
     }
@@ -259,7 +259,10 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
 
 void rt_Expression_eval(const AST_Expression_t *expr)
 {
-    if (!expr) return;
+    if (!expr) {
+        RT_VarTable_acc_setval(RT_Data_null());
+        return;
+    }
     /* take care pf fn calls and membership operations */
     switch (expr->op) {
         case LEXTOK_DOT:

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -223,6 +223,7 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
             /* convert expression to a data list */
             rt_Expression_eval(for_block->iterable.lst);
             RT_Data_t iterable = *RT_ACC_DATA;
+            RT_Data_copy(&iterable);
             int64_t length = 0;
             switch (iterable.type) {
                 case RT_DATA_TYPE_LST:

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -87,6 +87,21 @@ RT_Data_t RT_Data_null(void)
     return RT_Data_any(NULL);
 }
 
+void RT_Data_copy(RT_Data_t *var)
+{
+    switch (var->type) {
+        case RT_DATA_TYPE_STR:
+        case RT_DATA_TYPE_INTERP_STR:
+            RT_DataStr_copy(var->data.str);
+            break;
+        case RT_DATA_TYPE_LST:
+            RT_DataList_copy(var->data.lst);
+            break;
+        default:
+            break;
+    }
+}
+
 void RT_Data_destroy(RT_Data_t *var)
 {
     switch (var->type) {

--- a/src/runtime/data/list.c.h
+++ b/src/runtime/data/list.c.h
@@ -32,10 +32,20 @@ int64_t RT_DataList_length(const RT_DataList_t *lst)
     return lst->length;
 }
 
+void RT_DataList_copy(RT_DataList_t *lst)
+{
+    ++lst->rc;
+}
+
 void RT_DataList_destroy(RT_DataList_t **ptr)
 {
     if (!ptr || !*ptr) return;
     RT_DataList_t *lst = *ptr;
+    /* ref counting */
+    --lst->rc;
+    if (lst->rc < 0) lst->rc = 0;
+    if (lst->rc > 0) return;
+    /* free if rc 0 */
     for (int64_t i = 0; i < lst->length; i++) {
         RT_Data_t var = lst->var[i];
         if (var.type == RT_DATA_TYPE_STR || var.type == RT_DATA_TYPE_INTERP_STR) {

--- a/src/runtime/data/string.c.h
+++ b/src/runtime/data/string.c.h
@@ -38,10 +38,20 @@ int64_t RT_DataStr_length(const RT_DataStr_t *str)
     return str->length;
 }
 
+void RT_DataStr_copy(RT_DataStr_t *str)
+{
+    ++str->rc;
+}
+
 void RT_DataStr_destroy(RT_DataStr_t **ptr)
 {
     if (!ptr || !*ptr) return;
     RT_DataStr_t *str = *ptr;
+    /* ref counting */
+    --str->rc;
+    if (str->rc < 0) str->rc = 0;
+    if (str->rc > 0) return;
+    /* free if rc 0 */
     free(str->var);
     str->var = NULL;
     free(str);

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -229,6 +229,7 @@ RT_Data_t *RT_VarTable_getref(const char *varname)
         int tmp = rt_vtable_get_tempvar(varname);
         if (tmp >= 32) rt_throw("no argument at '%d': valid arguments are $[0] to $[31]", tmp);
         if (tmp >= 0) return &rt_vtable_temporary[tmp];
+        /* else fall back to code outside if-else ladder */
     }
     RT_VarTable_Proc_t *current_proc = &(rt_vtable->procs[rt_vtable->top]);
     for (int64_t i = current_proc->top; i >= 0; i--) {
@@ -241,6 +242,14 @@ RT_Data_t *RT_VarTable_getref(const char *varname)
     }
     /* variable not found, throw an error */
     rt_throw("undefined variable '%s'", varname);
+    return NULL;
+}
+
+RT_Data_t *RT_VarTable_getref_tmpvar(int tmpvar)
+{
+    if (tmpvar >= 32) rt_throw("no argument at '%d': valid arguments are $[0] to $[31]", tmpvar);
+    if (tmpvar >= 0) return &rt_vtable_temporary[tmpvar];
+    rt_throw("no argument at '%d': valid arguments are $[0] to $[31]", tmpvar);
     return NULL;
 }
 

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -169,7 +169,7 @@ void RT_VarTable_create(const char *varname, RT_Data_t value)
     } else {
         /* variable doesn't exist, add a new entry */
         int ret;
-        iter = kh_put(RT_Data_t, current_scope->scope, strdup(varname), &ret);
+        iter = kh_put(RT_Data_t, current_scope->scope, varname, &ret);
         /* create variable, increase reference count to 1 and set new data */
         RT_Data_copy(&value);
         kh_value(current_scope->scope, iter) = value;

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -55,17 +55,17 @@ RT_VarTable_Acc_t rt_vtable_accumulator = {
 RT_Data_t rt_vtable_temporary[RT_VTABLE_TEMPORARY_SIZE];
 
 /* few globally defined variables */
-RT_Data_t rt_vtable_lf         = { .data.chr = '\n',                    .type = RT_DATA_TYPE_CHR },
+RT_Data_t RT_VarTable_rsv_lf            = { .data.chr = '\n',                    .type = RT_DATA_TYPE_CHR },
 /* list of globally defined typename variables */
-          rt_vtable_bul        = { .data.chr = RT_DATA_TYPE_BUL,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_chr        = { .data.chr = RT_DATA_TYPE_CHR,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_i64        = { .data.chr = RT_DATA_TYPE_I64,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_f64        = { .data.chr = RT_DATA_TYPE_F64,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_str        = { .data.chr = RT_DATA_TYPE_STR,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_interp_str = { .data.chr = RT_DATA_TYPE_INTERP_STR, .type = RT_DATA_TYPE_I64 },
-          rt_vtable_lst        = { .data.chr = RT_DATA_TYPE_LST,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_any        = { .data.chr = RT_DATA_TYPE_ANY,        .type = RT_DATA_TYPE_I64 },
-          rt_vtable_null       = { .data.any = NULL ,                   .type = RT_DATA_TYPE_ANY };
+          RT_VarTable_typeid_bul        = { .data.i64 = RT_DATA_TYPE_BUL,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_chr        = { .data.i64 = RT_DATA_TYPE_CHR,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_i64        = { .data.i64 = RT_DATA_TYPE_I64,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_f64        = { .data.i64 = RT_DATA_TYPE_F64,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_str        = { .data.i64 = RT_DATA_TYPE_STR,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_interp_str = { .data.i64 = RT_DATA_TYPE_INTERP_STR, .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_lst        = { .data.i64 = RT_DATA_TYPE_LST,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_typeid_any        = { .data.i64 = RT_DATA_TYPE_ANY,        .type = RT_DATA_TYPE_I64 },
+          RT_VarTable_rsv_null          = { .data.any = NULL,                    .type = RT_DATA_TYPE_ANY };
 
 void RT_VarTable_push_proc(const char *procname, const AST_Statement_t *ret_addr)
 {
@@ -135,15 +135,15 @@ int rt_vtable_get_tempvar(const char *varname)
 
 RT_Data_t *rt_vtable_get_globvar(const char *varname)
 {
-    if (!strcmp("lf", varname))         return &rt_vtable_lf;
-    if (!strcmp("bul", varname))        return &rt_vtable_bul;
-    if (!strcmp("chr", varname))        return &rt_vtable_chr;
-    if (!strcmp("i64", varname))        return &rt_vtable_i64;
-    if (!strcmp("f64", varname))        return &rt_vtable_f64;
-    if (!strcmp("str", varname))        return &rt_vtable_str;
-    if (!strcmp("interp_str", varname)) return &rt_vtable_interp_str;
-    if (!strcmp("lst", varname))        return &rt_vtable_lst;
-    if (!strcmp("null", varname))       return &rt_vtable_null;
+    if (!strcmp("lf", varname))         return &RT_VarTable_rsv_lf;
+    if (!strcmp("bul", varname))        return &RT_VarTable_typeid_bul;
+    if (!strcmp("chr", varname))        return &RT_VarTable_typeid_chr;
+    if (!strcmp("i64", varname))        return &RT_VarTable_typeid_i64;
+    if (!strcmp("f64", varname))        return &RT_VarTable_typeid_f64;
+    if (!strcmp("str", varname))        return &RT_VarTable_typeid_str;
+    if (!strcmp("interp_str", varname)) return &RT_VarTable_typeid_interp_str;
+    if (!strcmp("lst", varname))        return &RT_VarTable_typeid_lst;
+    if (!strcmp("null", varname))       return &RT_VarTable_rsv_null;
     return NULL;
 }
 
@@ -179,7 +179,7 @@ void RT_VarTable_create(const char *varname, RT_Data_t value)
 RT_Data_t *RT_VarTable_modf(RT_Data_t *dest, RT_Data_t src)
 {
     if (!dest) return NULL;
-    if (dest == &rt_vtable_null) rt_throw("cannot assign to reserved identifier 'null'");
+    if (dest == &RT_VarTable_rsv_null) rt_throw("cannot assign to reserved identifier 'null'");
     RT_Data_destroy(dest);
     RT_Data_copy(&src);
     *dest = src;


### PR DESCRIPTION
- changed statements to right rec
- adding code to execute the return statement
- revert this commit: added test code to examples/helloworld.txt
- updated example
- updated return statement: return without params
- added fn to get tmpvar by var number
- bugfix: added the in keyword in lexer
- fn args: can be accessed via $[], $() and $i
- added fn args indexing
- return RT_Data_null if expr, lit, idf, or list is null
- replaced rt_table_refcnt_* fn with RT_Data_* fn
- the for loop must own the iterable
- updated built-in reserved identifiers
- added built in fn: len(), type(), refcnt()
- fixed a stupid memory leak
- updated example
