### PR TITLE
major fixes: bugs

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -7,6 +7,7 @@ typedef enum {
     FN_PRINT,
     FN_INPUT,
     FN_TYPE,
+    FN_TYPENAME,
     FN_LEN,
     FN_REFCNT,
     FN_UNDEFINED,

--- a/include/runtime/data.h
+++ b/include/runtime/data.h
@@ -53,6 +53,7 @@ bool RT_Data_isnull(const RT_Data_t var);
 char *RT_Data_interp_str_parse(const char *str);
 bool RT_Data_tobool(const RT_Data_t var);
 char *RT_Data_tostr(const RT_Data_t var);
+char *RT_Data_typename(const RT_Data_t var);
 int RT_Data_print(const RT_Data_t var);
 
 #endif

--- a/include/runtime/data.h
+++ b/include/runtime/data.h
@@ -53,7 +53,7 @@ bool RT_Data_isnull(const RT_Data_t var);
 char *RT_Data_interp_str_parse(const char *str);
 bool RT_Data_tobool(const RT_Data_t var);
 char *RT_Data_tostr(const RT_Data_t var);
-char *RT_Data_typename(const RT_Data_t var);
+const char *RT_Data_typename(const RT_Data_t var);
 int RT_Data_print(const RT_Data_t var);
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,9 +31,10 @@ SUB_DIR_DBG    := $(SUB_DIRS)
 
 ## source code headers
 
-LEXER_SRC_CH       := $(shell find $(SRC_DIR)/lexer/ -name "*".$(SRCEXT).$(HEADEREXT))
-# PARSER_SRC_CH    := $(shell find $(SRC_DIR)/parser/ -name "*".$(SRCEXT).$(HEADEREXT))
-FUNCTIONS_SRC_CH   := $(shell find $(SRC_DIR)/functions/ -name "*".$(SRCEXT).$(HEADEREXT))
+AST_SRC_CH     := $(shell find $(SRC_DIR)/ast/ -name "*".$(SRCEXT).$(HEADEREXT))
+LEXER_SRC_CH   := $(shell find $(SRC_DIR)/lexer/ -name "*".$(SRCEXT).$(HEADEREXT))
+PARSER_SRC_CH  := $(shell find $(SRC_DIR)/parser/ -name "*".$(SRCEXT).$(HEADEREXT))
+RUNTIME_SRC_CH := $(shell find $(SRC_DIR)/runtime/ -name "*".$(SRCEXT).$(HEADEREXT))
 
 ## release build
 
@@ -41,11 +42,17 @@ OBJECTS        := $(patsubst %.$(SRCEXT), %-rel.$(OBJEXT), $(wildcard *.$(SRCEXT
 
 rel: mkdirp $(OBJECTS) cpobj
 
+ast.$(OBJEXT): ast.$(SRCEXT) $(AST_SRC_CH) $(HEADERS)
+	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o ast.$(OBJEXT) ast.$(SRCEXT)
+
 lexer-rel.$(OBJEXT): lexer.$(SRCEXT) $(LEXER_SRC_CH) $(HEADERS)
 	$(CC) $(CFLAGS) $(INCLUDE) -c -o lexer-rel.$(OBJEXT) lexer.$(SRCEXT)
 
-# parser-rel.$(OBJEXT): parser.$(SRCEXT) $(PARSER_SRC_CH) $(HEADERS) \
+parser-rel.$(OBJEXT): parser.$(SRCEXT) $(PARSER_SRC_CH) $(HEADERS)
 	$(CC) $(CFLAGS) $(INCLUDE) -c -o parser-rel.$(OBJEXT) parser.$(SRCEXT)
+
+runtime.$(OBJEXT): runtime.$(SRCEXT) $(RUNTIME_SRC_CH) $(HEADERS)
+	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o runtime.$(OBJEXT) runtime.$(SRCEXT)
 
 %-rel.$(OBJEXT): %.$(SRCEXT) $(HEADERS)
 	$(CC) $(CFLAGS) $(INCLUDE) -c -o $@ $<
@@ -60,11 +67,17 @@ DBG_OBJECTS    := $(patsubst %.$(SRCEXT), %-dbg.$(OBJEXT), $(wildcard *.$(SRCEXT
 
 dbg: mkdirp $(DBG_OBJECTS) cpobj
 
+ast-dbg.$(OBJEXT): ast.$(SRCEXT) $(AST_SRC_CH) $(HEADERS)
+	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o ast-dbg.$(OBJEXT) ast.$(SRCEXT)
+
 lexer-dbg.$(OBJEXT): lexer.$(SRCEXT) $(LEXER_SRC_CH) $(HEADERS)
 	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o lexer-dbg.$(OBJEXT) lexer.$(SRCEXT)
 
-# parser-dbg.$(OBJEXT): parser.$(SRCEXT) $(PARSER_SRC_CH) $(HEADERS) \
+parser-dbg.$(OBJEXT): parser.$(SRCEXT) $(PARSER_SRC_CH) $(HEADERS)
 	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o parser-dbg.$(OBJEXT) parser.$(SRCEXT)
+
+runtime-dbg.$(OBJEXT): runtime.$(SRCEXT) $(RUNTIME_SRC_CH) $(HEADERS)
+	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o runtime-dbg.$(OBJEXT) runtime.$(SRCEXT)
 
 %-dbg.$(OBJEXT): %.$(SRCEXT) $(HEADERS)
 	$(CC) $(CDBGFLAGS) $(INCLUDE) -c -o $@ $<

--- a/src/functions.c
+++ b/src/functions.c
@@ -146,32 +146,32 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
         case FN_LEN: {
             const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
             switch (data.type) {
-            case RT_DATA_TYPE_STR:
-            case RT_DATA_TYPE_INTERP_STR:
-                ret = RT_Data_i64(RT_DataStr_length(data.data.str));
-                break;
-            case RT_DATA_TYPE_LST:
-                ret = RT_Data_i64(RT_DataList_length(data.data.lst));
-                break;
-            default:
-                ret = RT_Data_i64(1);
-                break;
+                case RT_DATA_TYPE_STR:
+                case RT_DATA_TYPE_INTERP_STR:
+                    ret = RT_Data_i64(RT_DataStr_length(data.data.str));
+                    break;
+                case RT_DATA_TYPE_LST:
+                    ret = RT_Data_i64(RT_DataList_length(data.data.lst));
+                    break;
+                default:
+                    ret = RT_Data_i64(1);
+                    break;
             }
             break;
         }
         case FN_REFCNT: {
             const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
             switch (data.type) {
-            case RT_DATA_TYPE_STR:
-            case RT_DATA_TYPE_INTERP_STR:
-                ret = RT_Data_i64(data.data.str->rc);
-                break;
-            case RT_DATA_TYPE_LST:
-                ret = RT_Data_i64(data.data.lst->rc);
-                break;
-            default:
-                ret = RT_Data_i64(1);
-                break;
+                case RT_DATA_TYPE_STR:
+                case RT_DATA_TYPE_INTERP_STR:
+                    ret = RT_Data_i64(data.data.str->rc);
+                    break;
+                case RT_DATA_TYPE_LST:
+                    ret = RT_Data_i64(data.data.lst->rc);
+                    break;
+                default:
+                    ret = RT_Data_i64(1);
+                    break;
             }
             break;
         }

--- a/src/functions.c
+++ b/src/functions.c
@@ -43,8 +43,7 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
         case FN_PRINT: {
             int bytes = 0;
             for (int i = 0; i < RT_TMPVAR_CNT; ++i) {
-                const char var[4] = { ((i % 100) / 10) + '0', (i % 10) + '0', '\0' };
-                const RT_Data_t data = *RT_VarTable_getref(var);
+                const RT_Data_t data = *RT_VarTable_getref_tmpvar(i);
                 if (RT_Data_isnull(data)) continue;
                 if (i > 0) printf(" ");
                 bytes += RT_Data_print(data);
@@ -53,8 +52,8 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
             break;
         }
         case FN_INPUT: {
-            const RT_Data_t prompt = *RT_VarTable_getref("0");
-            const RT_Data_t type_ = *RT_VarTable_getref("1");
+            const RT_Data_t prompt = *RT_VarTable_getref_tmpvar(0);
+            const RT_Data_t type_ = *RT_VarTable_getref_tmpvar(1);
             if (type_.type != RT_DATA_TYPE_I64) {
                 char *s = RT_Data_tostr(type_);
                 rt_throw(
@@ -114,8 +113,7 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
             break;
         }
         case FN_TYPE: {
-            const char var[4] = "0";
-            const RT_Data_t data = *RT_VarTable_getref(var);
+            const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
             switch (data.type) {
                 case RT_DATA_TYPE_BUL:
                     ret = RT_VarTable_typeid_bul;
@@ -146,8 +144,7 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
             break;
         }
         case FN_LEN: {
-            const char var[4] = "0";
-            const RT_Data_t data = *RT_VarTable_getref(var);
+            const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
             switch (data.type) {
             case RT_DATA_TYPE_STR:
             case RT_DATA_TYPE_INTERP_STR:
@@ -163,8 +160,7 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
             break;
         }
         case FN_REFCNT: {
-            const char var[4] = "0";
-            const RT_Data_t data = *RT_VarTable_getref(var);
+            const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
             switch (data.type) {
             case RT_DATA_TYPE_STR:
             case RT_DATA_TYPE_INTERP_STR:

--- a/src/functions.c
+++ b/src/functions.c
@@ -28,11 +28,12 @@ int fn_input_str(char **val);
 
 FN_FunctionDescriptor_t FN_FunctionsList_getfn(const char *fname)
 {
-    if (!strcmp(fname, "print")) return FN_PRINT;
-    if (!strcmp(fname, "input")) return FN_INPUT;
-    if (!strcmp(fname, "type")) return FN_TYPE;
-    if (!strcmp(fname, "len")) return FN_LEN;
-    if (!strcmp(fname, "refcnt")) return FN_REFCNT;
+    if (!strcmp(fname, "print"))    return FN_PRINT;
+    if (!strcmp(fname, "input"))    return FN_INPUT;
+    if (!strcmp(fname, "type"))     return FN_TYPE;
+    if (!strcmp(fname, "typename")) return FN_TYPENAME;
+    if (!strcmp(fname, "len"))      return FN_LEN;
+    if (!strcmp(fname, "refcnt"))   return FN_REFCNT;
     return FN_UNDEFINED;
 }
 
@@ -141,6 +142,12 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
                         RT_VarTable_rsv_null : RT_VarTable_typeid_any;
                     break;
             }
+            break;
+        }
+        case FN_TYPENAME: {
+            const RT_Data_t data = *RT_VarTable_getref_tmpvar(0);
+            const char *typename = RT_Data_typename(data);
+            ret = RT_Data_str(RT_DataStr_init(typename));
             break;
         }
         case FN_LEN: {

--- a/src/functions.c
+++ b/src/functions.c
@@ -58,8 +58,8 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
                 char *s = RT_Data_tostr(type_);
                 rt_throw(
                     "input: invalid type parameter: '%s'\n"
-                    "  valid parameters: `bul`, `chr`, `i64`, `f64` or `str`"
-                    "  values are: `%d`, `%d`, `%d`, `%d` or `%d` respectively", s,
+                    "  valid parameters are bul, chr, i64, f64 or str\n"
+                    "  respective values are %d, %d, %d, %d or %d", s,
                     RT_DATA_TYPE_BUL, RT_DATA_TYPE_CHR, RT_DATA_TYPE_I64, RT_DATA_TYPE_F64, RT_DATA_TYPE_STR);
                 free(s);
             }
@@ -67,8 +67,8 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
             if (!fn_isvalid_input_type(type_.data.i64))
                 rt_throw(
                     "input: invalid type parameter\n"
-                    "  valid parameters: `bul`, `chr`, `i64`, `f64` or `str`\n"
-                    "  values are: `%d`, `%d`, `%d`, `%d` or `%d` respectively",
+                    "  valid parameters are bul, chr, i64, f64 or str\n"
+                    "  respective values are %d, %d, %d, %d or %d",
                     RT_DATA_TYPE_BUL, RT_DATA_TYPE_CHR, RT_DATA_TYPE_I64, RT_DATA_TYPE_F64, RT_DATA_TYPE_STR);
             RT_Data_print(prompt);
             switch (type) {
@@ -105,8 +105,8 @@ RT_Data_t FN_FunctionsList_call(FN_FunctionDescriptor_t fn)
                 }
                 default: rt_throw(
                     "input: invalid type parameter\n"
-                    "  valid parameters: `bul`, `chr`, `i64`, `f64` or `str`\n"
-                    "  values are: `%d`, `%d`, `%d`, `%d` or `%d` respectively",
+                    "  valid parameters are bul, chr, i64, f64 or str\n"
+                    "  respective values are %d, %d, %d, %d or %d",
                     RT_DATA_TYPE_BUL, RT_DATA_TYPE_CHR, RT_DATA_TYPE_I64, RT_DATA_TYPE_F64, RT_DATA_TYPE_STR);
                     break;
             }
@@ -205,7 +205,7 @@ void fn_input_bul(bool *val)
     else if (!strncmp("0", str, len)) *val = false;
     else if (!strncmp("true", str, len)) *val = true;
     else if (!strncmp("false", str, len)) *val = false;
-    else rt_throw("input: invalid input for type `bul`: '%s'", str);
+    else rt_throw("input: invalid input for type bul: '%s'", str);
     free(str);
 }
 
@@ -216,7 +216,7 @@ void fn_input_chr(char *val)
     int len = fn_input_str(&str);
     if (len == 1) *val = str[0];
     else if (len == 0) *val = 0;
-    else rt_throw("input: invalid input for type `chr`: '%s'", str);
+    else rt_throw("input: invalid input for type chr: '%s'", str);
     free(str);
 }
 
@@ -229,7 +229,7 @@ void fn_input_i64(int64_t *val)
     errno = 0;
     *val = (int64_t) strtoll(str, &endptr, 10);
     if (errno || *endptr != '\0')
-        rt_throw("input: invalid input for type `i64`: '%s'", str);
+        rt_throw("input: invalid input for type i64: '%s'", str);
     free(str);
 }
 
@@ -242,7 +242,7 @@ void fn_input_f64(double *val)
     errno = 0;
     *val = (double) strtod(str, &endptr);
     if (errno || *endptr != '\0')
-        rt_throw("input: invalid input for type `f64`: '%s'", str);
+        rt_throw("input: invalid input for type f64: '%s'", str);
     free(str);
 }
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -189,17 +189,17 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
             rt_Expression_eval(for_block->iterable.range.start);
             RT_Data_t start = *RT_ACC_DATA;
             if (start.type != RT_DATA_TYPE_I64)
-                rt_throw("for loop range start should be an i64");
+                rt_throw("for loop range start should be an i64, not '%s'", RT_Data_typename(start));
             rt_Expression_eval(for_block->iterable.range.end);
             RT_Data_t end = *RT_ACC_DATA;
             if (end.type != RT_DATA_TYPE_I64)
-                rt_throw("for loop range end should be an i64");
+                rt_throw("for loop range end should be an i64, not '%s'", RT_Data_typename(start));
             RT_Data_t by = RT_Data_null();
             if (for_block->iterable.range.by) {
                 rt_Expression_eval(for_block->iterable.range.by);
                 by = *RT_ACC_DATA;
                 if (by.type != RT_DATA_TYPE_I64)
-                    rt_throw("for loop by value should be an i64");
+                    rt_throw("for loop by value should be an i64, not '%s'", RT_Data_typename(start));
             }
             const int64_t start_i = start.data.i64;
             const int64_t end_i = end.data.i64;
@@ -233,7 +233,7 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
                     length = RT_DataStr_length(iterable.data.str);
                     break;
                 default:
-                    rt_throw("unsupported for loop iterable type");
+                    rt_throw("not a for loop iterable type: '%s'", RT_Data_typename(iterable));
             }
             for (int64_t i = 0; i < length; ++i) {
                 RT_VarTable_push_scope();
@@ -247,7 +247,7 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
                             RT_Data_chr(*RT_DataStr_getref(iterable.data.str, i)));
                         break;
                     default:
-                        rt_throw("unsupported for loop iterable type");
+                        rt_throw("not a for loop iterable type: '%s'", RT_Data_typename(iterable));
                 }
                 bool return_ = rt_Statements_eval(for_block->statements);
                 RT_VarTable_pop_scope();

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -255,6 +255,7 @@ void rt_ForBlock_eval(const AST_ForBlock_t *for_block)
             }
             /* destroy iterable object */
             RT_Data_destroy(&iterable);
+            break;
         }
     }
 }
@@ -360,14 +361,12 @@ void rt_Expression_eval(const AST_Expression_t *expr)
         case LEXTOK_MULTIPLY_ASSIGN:
         case LEXTOK_PLUS:
         case LEXTOK_INCREMENT:
-            rt_throw("unary increment operator is not yet supported");
-            break;
         case LEXTOK_ADD_ASSIGN:
         case LEXTOK_MINUS:
         case LEXTOK_DECREMENT:
-            rt_throw("unary decrement operator is not yet supported");
-            break;
         case LEXTOK_SUBSTRACT_ASSIGN:
+            rt_throw("unimplemented operators");
+            break;
         case LEXTOK_DOT:
             rt_throw("memebership operator '.' is not yet supported");
             break;
@@ -376,12 +375,12 @@ void rt_Expression_eval(const AST_Expression_t *expr)
         case LEXTOK_FLOOR_DIVIDE_ASSIGN:
         case LEXTOK_DIVIDE_ASSIGN:
         case LEXTOK_DCOLON:
-            rt_throw("memebership operator '::' is not yet supported");
-            break;
         case LEXTOK_LBRACE_ANGULAR:
         case LEXTOK_BITWISE_LSHIFT:
         case LEXTOK_BITWISE_LSHIFT_ASSIGN:
         case LEXTOK_LOGICAL_LESSER_EQUAL:
+            rt_throw("unimplemented operators");
+            break;
         case LEXTOK_ASSIGN:
             RT_VarTable_acc_setval(*RT_VarTable_modf(lhs, *rhs));
             break;
@@ -399,9 +398,11 @@ void rt_Expression_eval(const AST_Expression_t *expr)
         case LEXTOK_LOGICAL_OR:
         case LEXTOK_LOGICAL_OR_ASSIGN:
         case LEXTOK_TILDE:
-        case TOKOP_FNCALL: break;
+        case TOKOP_FNCALL:
         case TOKOP_INDEXING:
         case TOKOP_TERNARY_COND:
+            rt_throw("unimplemented operators");
+            break;
         case TOKOP_FNARGS_INDEXING:
             if (!rhs || rhs->type != RT_DATA_TYPE_I64)
                 rt_throw("argument index should evaluate to an `i64`");

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -276,11 +276,13 @@ void rt_Expression_eval(const AST_Expression_t *expr)
                 expr->rhs.literal->data.lst : NULL;
             /* copy fn args into temporary location */
             for (int i = 0; i < RT_TMPVAR_CNT; ++i) {
-                const char var[4] = { ((i % 100) / 10) + '0', (i % 10) + '0', '\0' };
-                if (ptr) rt_Expression_eval(ptr->expression);
-                RT_Data_t data = ptr ? *RT_ACC_DATA : RT_Data_null();
-                RT_VarTable_modf(RT_VarTable_getref(var), data);
-                ptr = ptr ? ptr->comma_list : ptr;
+                RT_Data_t data = RT_Data_null();
+                if (ptr) {
+                    rt_Expression_eval(ptr->expression);
+                    data = *RT_ACC_DATA;
+                }
+                RT_VarTable_modf(RT_VarTable_getref_tmpvar(i), data);
+                if (ptr) ptr = ptr->comma_list;
             }
             /* get fn code and push code to stack */
             rt_fncall_handler(rt_modulename_get(), expr->lhs.variable);

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -254,7 +254,7 @@ char *RT_Data_tostr(const RT_Data_t var)
     }
 }
 
-char *RT_Data_typename(const RT_Data_t var)
+const char *RT_Data_typename(const RT_Data_t var)
 {
     switch (var.type) {
         case RT_DATA_TYPE_BUL:        return "bul";

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -119,6 +119,7 @@ void RT_Data_destroy(RT_Data_t *var)
         default:
             break;
     }
+    *var = RT_Data_null();
 }
 
 bool RT_Data_isnull(const RT_Data_t var)

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -254,6 +254,21 @@ char *RT_Data_tostr(const RT_Data_t var)
     }
 }
 
+char *RT_Data_typename(const RT_Data_t var)
+{
+    switch (var.type) {
+        case RT_DATA_TYPE_BUL:        return "bul";
+        case RT_DATA_TYPE_CHR:        return "chr";
+        case RT_DATA_TYPE_I64:        return "i64";
+        case RT_DATA_TYPE_F64:        return "f64";
+        case RT_DATA_TYPE_STR:        return "str";
+        case RT_DATA_TYPE_INTERP_STR: return "interp_str";
+        case RT_DATA_TYPE_LST:        return "lst";
+        case RT_DATA_TYPE_ANY:        return var.data.any ? "any" : "null";
+    }
+    return NULL;
+}
+
 int RT_Data_print(RT_Data_t var)
 {
     char *str = RT_Data_tostr(var);

--- a/src/runtime/data.c.h
+++ b/src/runtime/data.c.h
@@ -108,18 +108,22 @@ void RT_Data_destroy(RT_Data_t *var)
         case RT_DATA_TYPE_STR:
         case RT_DATA_TYPE_INTERP_STR:
             RT_DataStr_destroy(&var->data.str);
+            if (!var->data.str) *var = RT_Data_null();
             break;
         case RT_DATA_TYPE_LST:
             RT_DataList_destroy(&var->data.lst);
+            if (!var->data.lst) *var = RT_Data_null();
             break;
         case RT_DATA_TYPE_ANY:
             if (var->data.any) free(var->data.any);
             var->data.any = NULL;
+            *var = RT_Data_null();
             break;
         default:
+            /* assigning non-composite data to RT_VarTable_null
+               corrupts data in case *var points to a rt_ global var */
             break;
     }
-    *var = RT_Data_null();
 }
 
 bool RT_Data_isnull(const RT_Data_t var)

--- a/src/runtime/data/list.c.h
+++ b/src/runtime/data/list.c.h
@@ -46,15 +46,8 @@ void RT_DataList_destroy(RT_DataList_t **ptr)
     if (lst->rc < 0) lst->rc = 0;
     if (lst->rc > 0) return;
     /* free if rc 0 */
-    for (int64_t i = 0; i < lst->length; i++) {
-        RT_Data_t var = lst->var[i];
-        if (var.type == RT_DATA_TYPE_STR || var.type == RT_DATA_TYPE_INTERP_STR) {
-            free(var.data.str);
-            var.data.str = NULL;
-            var.type = RT_DATA_TYPE_ANY;
-        } else if (var.type == RT_DATA_TYPE_LST)
-            RT_DataList_destroy(&var.data.lst);
-    }
+    for (int64_t i = 0; i < lst->length; i++)
+        RT_Data_destroy(&lst->var[i]);
     free(lst->var);
     lst->var = NULL;
     free(lst);
@@ -82,9 +75,7 @@ RT_Data_t *RT_DataList_getref(const RT_DataList_t *lst, int64_t idx)
 void RT_DataList_del_index(RT_DataList_t *lst, int64_t idx)
 {
     if (idx >= 0 && idx < lst->length) {
-        RT_Data_t var = lst->var[idx];
-        if (var.type == RT_DATA_TYPE_STR || var.type == RT_DATA_TYPE_INTERP_STR)
-            free(var.data.str);
+        RT_Data_destroy(&lst->var[idx]);
         for (int64_t i = idx + 1; i < lst->length; i++)
             lst->var[i-1] = lst->var[i];
         --lst->length;

--- a/src/runtime/data/list.c.h
+++ b/src/runtime/data/list.c.h
@@ -56,6 +56,7 @@ void RT_DataList_destroy(RT_DataList_t **ptr)
 
 void RT_DataList_append(RT_DataList_t *lst, RT_Data_t var)
 {
+    RT_Data_copy(&var);
     if (lst->length >= lst->capacity) {
         lst->capacity = lst->capacity * 2 +1;
         lst->var = (RT_Data_t*) realloc(lst->var, lst->capacity * sizeof(RT_Data_t));

--- a/src/runtime/data/list.c.h
+++ b/src/runtime/data/list.c.h
@@ -95,28 +95,28 @@ void RT_DataList_del_val(RT_DataList_t *lst, RT_Data_t var)
 
 char *RT_DataList_tostr(const RT_DataList_t *lst)
 {
-    char *str = (char*) malloc(3 * sizeof(char));
+    size_t size = 3;
+    char *str = (char*) malloc(size * sizeof(char));
     if (!str) io_errndie("RT_DataList_tostr:" ERR_MSG_MALLOCFAIL);
     int p = 0;
-    size_t size = 3;
-    sprintf(str + p++, "[");
+    sprintf(&str[p++], "[");
     for (int64_t i = 0; i < lst->length; ++i) {
         char *lst_el = RT_Data_tostr(lst->var[i]);
         const size_t sz = strlen(lst_el) +1;
         str = (char*) realloc(str, (size += sz) * sizeof(char));
         if (!str) io_errndie("RT_DataList_tostr:" ERR_MSG_REALLOCFAIL);
-        sprintf(str + p, "%s", lst_el);
+        sprintf(&str[p], "%s", lst_el);
         free(lst_el);
         lst_el = NULL;
-        p += sz;
+        p += sz -1;
         if (i != lst->length - 1) {
             str = (char*) realloc(str, (size += 2) * sizeof(char));
             if (!str) io_errndie("RT_DataList_tostr:" ERR_MSG_REALLOCFAIL);
-            sprintf(str + p, ", ");
+            sprintf(&str[p], ", ");
             p += 2;
         }
     }
-    sprintf(str + p++, "]");
+    sprintf(&str[p++], "]");
     return str;
 }
 

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -1,6 +1,7 @@
 #ifndef RT_VARTABLE_C_H
 #define RT_VARTABLE_C_H
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
@@ -149,7 +150,7 @@ RT_Data_t *rt_vtable_get_globvar(const char *varname)
 
 void RT_VarTable_create(const char *varname, RT_Data_t value)
 {
-    if (!strcmp(varname, "-"))
+    if ( (!isalpha(varname[0]) && varname[0] != '_') || isdigit(varname[0]) )
         io_errndie("RT_VarTable_create: invalid new variable name '%s'", varname);
     else {
         RT_Data_t *globvar = rt_vtable_get_globvar(varname);
@@ -188,8 +189,8 @@ RT_Data_t *RT_VarTable_modf(RT_Data_t *dest, RT_Data_t src)
 
 RT_Data_t *RT_VarTable_getref(const char *varname)
 {
-    if (!strcmp(varname, "-"))
-        io_errndie("RT_VarTable_getref: accumulator must be accessed via 'RT_VarTable_acc_get' or 'RT_VarTable_acc_set'");
+    if ( (!isalpha(varname[0]) && varname[0] != '_') || isdigit(varname[0]) )
+        io_errndie("RT_VarTable_getref: invalid variable name '%s'", varname);
     else {
         RT_Data_t *globvar = rt_vtable_get_globvar(varname);
         if (globvar) return globvar;

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -17,10 +17,6 @@
 #include "runtime/io.h"
 #include "runtime/vartable.h"
 
-#define RT_VTABLE_TEMPORARY_SIZE (32)
-
-int rt_vtable_get_tempvar(const char *varname);
-
 KHASH_MAP_INIT_STR(RT_Data_t, RT_Data_t)
 
 /** local scope, stores a map of variables */
@@ -53,7 +49,7 @@ RT_VarTable_Acc_t rt_vtable_accumulator = {
     .adr = NULL
 };
 
-RT_Data_t rt_vtable_temporary[RT_VTABLE_TEMPORARY_SIZE];
+RT_Data_t rt_vtable_tmpvars[RT_TMPVAR_CNT];
 
 /* few globally defined variables */
 RT_Data_t RT_VarTable_rsv_lf            = { .data.chr = '\n',                    .type = RT_DATA_TYPE_CHR },
@@ -215,9 +211,9 @@ RT_Data_t *RT_VarTable_getref(const char *varname)
 
 RT_Data_t *RT_VarTable_getref_tmpvar(int tmpvar)
 {
-    if (tmpvar >= 32) rt_throw("no argument at '%d': valid arguments are $[0] to $[31]", tmpvar);
-    if (tmpvar >= 0) return &rt_vtable_temporary[tmpvar];
-    rt_throw("no argument at '%d': valid arguments are $[0] to $[31]", tmpvar);
+    if (tmpvar >= RT_TMPVAR_CNT) rt_throw("no argument at '%d': valid arguments are $0 to $%d", tmpvar, RT_TMPVAR_CNT-1);
+    if (tmpvar >= 0) return &rt_vtable_tmpvars[tmpvar];
+    rt_throw("no argument at '%d': valid arguments are $0 to $%d", tmpvar, RT_TMPVAR_CNT-1);
     return NULL;
 }
 

--- a/tests/SyntaxTree.json
+++ b/tests/SyntaxTree.json
@@ -163,18 +163,21 @@
         "statements": [
           {
             "node": "statement",
-            "line_no": 6,
+            "line_no": 4,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
-              "lhs": null,
+              "lhs": {
+                "node": "identifier",
+                "identifier_name": "inp"
+              },
               "rhs": {
                 "node": "expression",
                 "op": "()",
                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
                   "node": "identifier",
-                  "identifier_name": "print"
+                  "identifier_name": "input"
                 },
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
@@ -190,7 +193,20 @@
                         "lhs": {
                           "node": "literal",
                           "type": "DATA_TYPE_STR",
-                          "data": "result = {res}\n"
+                          "data": "Enter a number: "
+                        },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      },
+                      {
+                        "node": "expression",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "i64"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -253,21 +269,18 @@
           },
           {
             "node": "statement",
-            "line_no": 4,
+            "line_no": 6,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
-              "lhs": {
-                "node": "identifier",
-                "identifier_name": "inp"
-              },
+              "lhs": null,
               "rhs": {
                 "node": "expression",
                 "op": "()",
                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
                   "node": "identifier",
-                  "identifier_name": "input"
+                  "identifier_name": "print"
                 },
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
@@ -283,20 +296,7 @@
                         "lhs": {
                           "node": "literal",
                           "type": "DATA_TYPE_STR",
-                          "data": "Enter a number: "
-                        },
-                        "rhs_type": "EXPR_TYPE_NULL",
-                        "rhs": null,
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      },
-                      {
-                        "node": "expression",
-                        "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                        "lhs": {
-                          "node": "identifier",
-                          "identifier_name": "i64"
+                          "data": "result = {res}\n"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -319,53 +319,54 @@
     "node": "module",
     "main": {
       "node": "procedure",
-      "file": "tests/test.txt",
+      "file": "examples/helloworld.txt",
       "statements": {
         "node": "statements",
         "statements": [
           {
             "node": "statement",
-            "line_no": 30,
-            "type": "STATEMENT_TYPE_COMPOUND",
+            "line_no": 16,
+            "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
-              "node": "if_block",
-              "condition": {
+              "node": "assignment",
+              "lhs": {
+                "node": "identifier",
+                "identifier_name": "ret"
+              },
+              "rhs": {
                 "node": "expression",
-                "op": "==",
+                "op": "()",
                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
                   "node": "identifier",
-                  "identifier_name": "y"
+                  "identifier_name": "test"
                 },
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
                   "node": "literal",
-                  "type": "DATA_TYPE_I64",
-                  "data": 5
-                },
-                "condition_type": "EXPR_TYPE_NULL",
-                "condition": null
-              },
-              "if_st": {
-                "node": "statements",
-                "statements": [
-                  {
-                    "node": "statement",
-                    "line_no": 29,
-                    "type": "STATEMENT_TYPE_ASSIGNMENT",
-                    "statement": {
-                      "node": "assignment",
-                      "lhs": null,
-                      "rhs": {
+                  "type": "DATA_TYPE_LST",
+                  "data": {
+                    "node": "comma_list",
+                    "comma_list": [
+                      {
                         "node": "expression",
-                        "op": "()",
-                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
                         "lhs": {
-                          "node": "identifier",
-                          "identifier_name": "print"
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "Times"
                         },
-                        "rhs_type": "EXPR_TYPE_LITERAL",
-                        "rhs": {
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      },
+                      {
+                        "node": "expression",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
+                        "lhs": {
                           "node": "literal",
                           "type": "DATA_TYPE_LST",
                           "data": {
@@ -377,8 +378,8 @@
                                 "lhs_type": "EXPR_TYPE_LITERAL",
                                 "lhs": {
                                   "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "x was false"
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 1
                                 },
                                 "rhs_type": "EXPR_TYPE_NULL",
                                 "rhs": null,
@@ -388,10 +389,53 @@
                               {
                                 "node": "expression",
                                 "op": "NOP",
-                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
                                 "lhs": {
-                                  "node": "identifier",
-                                  "identifier_name": "lf"
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 2
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 3
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 4
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 5
                                 },
                                 "rhs_type": "EXPR_TYPE_NULL",
                                 "rhs": null,
@@ -401,65 +445,22 @@
                             ]
                           }
                         },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
                         "condition_type": "EXPR_TYPE_NULL",
                         "condition": null
                       }
-                    }
+                    ]
                   }
-                ]
-              },
-              "else_block": null
-            }
-          },
-          {
-            "node": "statement",
-            "line_no": 27,
-            "type": "STATEMENT_TYPE_ASSIGNMENT",
-            "statement": {
-              "node": "assignment",
-              "lhs": {
-                "node": "identifier",
-                "identifier_name": "y"
-              },
-              "rhs": {
-                "node": "expression",
-                "op": "?:",
-                "lhs_type": "EXPR_TYPE_LITERAL",
-                "lhs": {
-                  "node": "literal",
-                  "type": "DATA_TYPE_I64",
-                  "data": 5
                 },
-                "rhs_type": "EXPR_TYPE_LITERAL",
-                "rhs": {
-                  "node": "literal",
-                  "type": "DATA_TYPE_I64",
-                  "data": 7
-                },
-                "condition_type": "EXPR_TYPE_EXPRESSION",
-                "condition": {
-                  "node": "expression",
-                  "op": "==",
-                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                  "lhs": {
-                    "node": "identifier",
-                    "identifier_name": "x"
-                  },
-                  "rhs_type": "EXPR_TYPE_LITERAL",
-                  "rhs": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_BUL",
-                    "data": false
-                  },
-                  "condition_type": "EXPR_TYPE_NULL",
-                  "condition": null
-                }
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
               }
             }
           },
           {
             "node": "statement",
-            "line_no": 26,
+            "line_no": 17,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
@@ -486,7 +487,20 @@
                         "lhs": {
                           "node": "literal",
                           "type": "DATA_TYPE_STR",
-                          "data": "bool value = {x}"
+                          "data": "Return val:"
+                        },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      },
+                      {
+                        "node": "expression",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "ret"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -513,10 +527,77 @@
                 "condition": null
               }
             }
+          }
+        ]
+      }
+    },
+    "xyz": {
+      "node": "procedure",
+      "file": "tests/test.txt",
+      "statements": {
+        "node": "statements",
+        "statements": [
+          {
+            "node": "statement",
+            "line_no": 4,
+            "type": "STATEMENT_TYPE_ASSIGNMENT",
+            "statement": {
+              "node": "assignment",
+              "lhs": null,
+              "rhs": {
+                "node": "expression",
+                "op": "()",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                "lhs": {
+                  "node": "identifier",
+                  "identifier_name": "print"
+                },
+                "rhs_type": "EXPR_TYPE_LITERAL",
+                "rhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_LST",
+                  "data": {
+                    "node": "comma_list",
+                    "comma_list": [
+                      {
+                        "node": "expression",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
+                        "lhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "Hello world!"
+                        },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      },
+                      {
+                        "node": "expression",
+                        "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
+                        "lhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "lf"
+                        },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    ]
+                  }
+                },
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              }
+            }
           },
           {
             "node": "statement",
-            "line_no": 25,
+            "line_no": 6,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
@@ -526,34 +607,11 @@
               },
               "rhs": {
                 "node": "expression",
-                "op": "NOP",
-                "lhs_type": "EXPR_TYPE_LITERAL",
-                "lhs": {
-                  "node": "literal",
-                  "type": "DATA_TYPE_BUL",
-                  "data": true
-                },
-                "rhs_type": "EXPR_TYPE_NULL",
-                "rhs": null,
-                "condition_type": "EXPR_TYPE_NULL",
-                "condition": null
-              }
-            }
-          },
-          {
-            "node": "statement",
-            "line_no": 22,
-            "type": "STATEMENT_TYPE_ASSIGNMENT",
-            "statement": {
-              "node": "assignment",
-              "lhs": null,
-              "rhs": {
-                "node": "expression",
                 "op": "()",
                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
                   "node": "identifier",
-                  "identifier_name": "print"
+                  "identifier_name": "input"
                 },
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
@@ -565,24 +623,10 @@
                       {
                         "node": "expression",
                         "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_LITERAL",
-                        "lhs": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_STR",
-                          "data": "entered {x}"
-                        },
-                        "rhs_type": "EXPR_TYPE_NULL",
-                        "rhs": null,
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      },
-                      {
-                        "node": "expression",
-                        "op": "NOP",
                         "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
                           "node": "identifier",
-                          "identifier_name": "lf"
+                          "identifier_name": "i64"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -594,187 +638,6 @@
                 },
                 "condition_type": "EXPR_TYPE_NULL",
                 "condition": null
-              }
-            }
-          },
-          {
-            "node": "statement",
-            "line_no": 21,
-            "type": "STATEMENT_TYPE_ASSIGNMENT",
-            "statement": {
-              "node": "assignment",
-              "lhs": null,
-              "rhs": {
-                "node": "expression",
-                "op": "=",
-                "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                "lhs": {
-                  "node": "identifier",
-                  "identifier_name": "x"
-                },
-                "rhs_type": "EXPR_TYPE_EXPRESSION",
-                "rhs": {
-                  "node": "expression",
-                  "op": "()",
-                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                  "lhs": {
-                    "node": "identifier",
-                    "identifier_name": "input"
-                  },
-                  "rhs_type": "EXPR_TYPE_LITERAL",
-                  "rhs": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_LST",
-                    "data": {
-                      "node": "comma_list",
-                      "comma_list": [
-                        {
-                          "node": "expression",
-                          "op": "NOP",
-                          "lhs_type": "EXPR_TYPE_LITERAL",
-                          "lhs": {
-                            "node": "literal",
-                            "type": "DATA_TYPE_STR",
-                            "data": "prompt: "
-                          },
-                          "rhs_type": "EXPR_TYPE_NULL",
-                          "rhs": null,
-                          "condition_type": "EXPR_TYPE_NULL",
-                          "condition": null
-                        },
-                        {
-                          "node": "expression",
-                          "op": "NOP",
-                          "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                          "lhs": {
-                            "node": "identifier",
-                            "identifier_name": "str"
-                          },
-                          "rhs_type": "EXPR_TYPE_NULL",
-                          "rhs": null,
-                          "condition_type": "EXPR_TYPE_NULL",
-                          "condition": null
-                        }
-                      ]
-                    }
-                  },
-                  "condition_type": "EXPR_TYPE_NULL",
-                  "condition": null
-                },
-                "condition_type": "EXPR_TYPE_NULL",
-                "condition": null
-              }
-            }
-          },
-          {
-            "node": "statement",
-            "line_no": 19,
-            "type": "STATEMENT_TYPE_COMPOUND",
-            "statement": {
-              "node": "while_block",
-              "condition": {
-                "node": "expression",
-                "op": ">=",
-                "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                "lhs": {
-                  "node": "identifier",
-                  "identifier_name": "x"
-                },
-                "rhs_type": "EXPR_TYPE_LITERAL",
-                "rhs": {
-                  "node": "literal",
-                  "type": "DATA_TYPE_I64",
-                  "data": 0
-                },
-                "condition_type": "EXPR_TYPE_NULL",
-                "condition": null
-              },
-              "statements": {
-                "node": "statements",
-                "statements": [
-                  {
-                    "node": "statement",
-                    "line_no": 18,
-                    "type": "STATEMENT_TYPE_ASSIGNMENT",
-                    "statement": {
-                      "node": "assignment",
-                      "lhs": null,
-                      "rhs": {
-                        "node": "expression",
-                        "op": "=",
-                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                        "lhs": {
-                          "node": "identifier",
-                          "identifier_name": "x"
-                        },
-                        "rhs_type": "EXPR_TYPE_EXPRESSION",
-                        "rhs": {
-                          "node": "expression",
-                          "op": "-",
-                          "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                          "lhs": {
-                            "node": "identifier",
-                            "identifier_name": "x"
-                          },
-                          "rhs_type": "EXPR_TYPE_LITERAL",
-                          "rhs": {
-                            "node": "literal",
-                            "type": "DATA_TYPE_I64",
-                            "data": 1
-                          },
-                          "condition_type": "EXPR_TYPE_NULL",
-                          "condition": null
-                        },
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      }
-                    }
-                  },
-                  {
-                    "node": "statement",
-                    "line_no": 17,
-                    "type": "STATEMENT_TYPE_ASSIGNMENT",
-                    "statement": {
-                      "node": "assignment",
-                      "lhs": null,
-                      "rhs": {
-                        "node": "expression",
-                        "op": "()",
-                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                        "lhs": {
-                          "node": "identifier",
-                          "identifier_name": "print"
-                        },
-                        "rhs_type": "EXPR_TYPE_LITERAL",
-                        "rhs": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_LST",
-                          "data": {
-                            "node": "comma_list",
-                            "comma_list": [
-                              {
-                                "node": "expression",
-                                "op": "NOP",
-                                "lhs_type": "EXPR_TYPE_LITERAL",
-                                "lhs": {
-                                  "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "x = {x}"
-                                },
-                                "rhs_type": "EXPR_TYPE_NULL",
-                                "rhs": null,
-                                "condition_type": "EXPR_TYPE_NULL",
-                                "condition": null
-                              }
-                            ]
-                          }
-                        },
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      }
-                    }
-                  }
-                ]
               }
             }
           },
@@ -1016,21 +879,199 @@
           },
           {
             "node": "statement",
-            "line_no": 6,
+            "line_no": 19,
+            "type": "STATEMENT_TYPE_COMPOUND",
+            "statement": {
+              "node": "while_block",
+              "condition": {
+                "node": "expression",
+                "op": ">=",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                "lhs": {
+                  "node": "identifier",
+                  "identifier_name": "x"
+                },
+                "rhs_type": "EXPR_TYPE_LITERAL",
+                "rhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 0
+                },
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              },
+              "statements": {
+                "node": "statements",
+                "statements": [
+                  {
+                    "node": "statement",
+                    "line_no": 17,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": null,
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "print"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "x = {x}"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  },
+                  {
+                    "node": "statement",
+                    "line_no": 18,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": null,
+                      "rhs": {
+                        "node": "expression",
+                        "op": "=",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "x"
+                        },
+                        "rhs_type": "EXPR_TYPE_EXPRESSION",
+                        "rhs": {
+                          "node": "expression",
+                          "op": "-",
+                          "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                          "lhs": {
+                            "node": "identifier",
+                            "identifier_name": "x"
+                          },
+                          "rhs_type": "EXPR_TYPE_LITERAL",
+                          "rhs": {
+                            "node": "literal",
+                            "type": "DATA_TYPE_I64",
+                            "data": 1
+                          },
+                          "condition_type": "EXPR_TYPE_NULL",
+                          "condition": null
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 21,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
-              "lhs": {
-                "node": "identifier",
-                "identifier_name": "x"
-              },
+              "lhs": null,
+              "rhs": {
+                "node": "expression",
+                "op": "=",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                "lhs": {
+                  "node": "identifier",
+                  "identifier_name": "x"
+                },
+                "rhs_type": "EXPR_TYPE_EXPRESSION",
+                "rhs": {
+                  "node": "expression",
+                  "op": "()",
+                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                  "lhs": {
+                    "node": "identifier",
+                    "identifier_name": "input"
+                  },
+                  "rhs_type": "EXPR_TYPE_LITERAL",
+                  "rhs": {
+                    "node": "literal",
+                    "type": "DATA_TYPE_LST",
+                    "data": {
+                      "node": "comma_list",
+                      "comma_list": [
+                        {
+                          "node": "expression",
+                          "op": "NOP",
+                          "lhs_type": "EXPR_TYPE_LITERAL",
+                          "lhs": {
+                            "node": "literal",
+                            "type": "DATA_TYPE_STR",
+                            "data": "prompt: "
+                          },
+                          "rhs_type": "EXPR_TYPE_NULL",
+                          "rhs": null,
+                          "condition_type": "EXPR_TYPE_NULL",
+                          "condition": null
+                        },
+                        {
+                          "node": "expression",
+                          "op": "NOP",
+                          "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                          "lhs": {
+                            "node": "identifier",
+                            "identifier_name": "str"
+                          },
+                          "rhs_type": "EXPR_TYPE_NULL",
+                          "rhs": null,
+                          "condition_type": "EXPR_TYPE_NULL",
+                          "condition": null
+                        }
+                      ]
+                    }
+                  },
+                  "condition_type": "EXPR_TYPE_NULL",
+                  "condition": null
+                },
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 22,
+            "type": "STATEMENT_TYPE_ASSIGNMENT",
+            "statement": {
+              "node": "assignment",
+              "lhs": null,
               "rhs": {
                 "node": "expression",
                 "op": "()",
                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
                   "node": "identifier",
-                  "identifier_name": "input"
+                  "identifier_name": "print"
                 },
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
@@ -1042,10 +1083,24 @@
                       {
                         "node": "expression",
                         "op": "NOP",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
+                        "lhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "entered {x}"
+                        },
+                        "rhs_type": "EXPR_TYPE_NULL",
+                        "rhs": null,
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      },
+                      {
+                        "node": "expression",
+                        "op": "NOP",
                         "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
                           "node": "identifier",
-                          "identifier_name": "i64"
+                          "identifier_name": "lf"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -1062,7 +1117,33 @@
           },
           {
             "node": "statement",
-            "line_no": 4,
+            "line_no": 25,
+            "type": "STATEMENT_TYPE_ASSIGNMENT",
+            "statement": {
+              "node": "assignment",
+              "lhs": {
+                "node": "identifier",
+                "identifier_name": "x"
+              },
+              "rhs": {
+                "node": "expression",
+                "op": "NOP",
+                "lhs_type": "EXPR_TYPE_LITERAL",
+                "lhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_BUL",
+                  "data": true
+                },
+                "rhs_type": "EXPR_TYPE_NULL",
+                "rhs": null,
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 26,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
@@ -1089,7 +1170,7 @@
                         "lhs": {
                           "node": "literal",
                           "type": "DATA_TYPE_STR",
-                          "data": "Hello world!"
+                          "data": "bool value = {x}"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -1116,11 +1197,145 @@
                 "condition": null
               }
             }
+          },
+          {
+            "node": "statement",
+            "line_no": 27,
+            "type": "STATEMENT_TYPE_ASSIGNMENT",
+            "statement": {
+              "node": "assignment",
+              "lhs": {
+                "node": "identifier",
+                "identifier_name": "y"
+              },
+              "rhs": {
+                "node": "expression",
+                "op": "?:",
+                "lhs_type": "EXPR_TYPE_LITERAL",
+                "lhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 5
+                },
+                "rhs_type": "EXPR_TYPE_LITERAL",
+                "rhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 7
+                },
+                "condition_type": "EXPR_TYPE_EXPRESSION",
+                "condition": {
+                  "node": "expression",
+                  "op": "==",
+                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                  "lhs": {
+                    "node": "identifier",
+                    "identifier_name": "x"
+                  },
+                  "rhs_type": "EXPR_TYPE_LITERAL",
+                  "rhs": {
+                    "node": "literal",
+                    "type": "DATA_TYPE_BUL",
+                    "data": false
+                  },
+                  "condition_type": "EXPR_TYPE_NULL",
+                  "condition": null
+                }
+              }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 30,
+            "type": "STATEMENT_TYPE_COMPOUND",
+            "statement": {
+              "node": "if_block",
+              "condition": {
+                "node": "expression",
+                "op": "==",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                "lhs": {
+                  "node": "identifier",
+                  "identifier_name": "y"
+                },
+                "rhs_type": "EXPR_TYPE_LITERAL",
+                "rhs": {
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 5
+                },
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              },
+              "if_st": {
+                "node": "statements",
+                "statements": [
+                  {
+                    "node": "statement",
+                    "line_no": 29,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": null,
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "print"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "x was false"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs": {
+                                  "node": "identifier",
+                                  "identifier_name": "lf"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  }
+                ]
+              },
+              "else_block": null
+            }
           }
         ]
       }
     },
-    "hello": {
+    "test": {
       "node": "procedure",
       "file": "examples/helloworld.txt",
       "statements": {
@@ -1128,59 +1343,326 @@
         "statements": [
           {
             "node": "statement",
-            "line_no": 2,
+            "line_no": 4,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
-              "lhs": null,
+              "lhs": {
+                "node": "identifier",
+                "identifier_name": "times"
+              },
               "rhs": {
                 "node": "expression",
-                "op": "()",
-                "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                "lhs": {
-                  "node": "identifier",
-                  "identifier_name": "print"
-                },
+                "op": "$[]",
+                "lhs_type": "EXPR_TYPE_NULL",
+                "lhs": null,
                 "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
                   "node": "literal",
-                  "type": "DATA_TYPE_LST",
-                  "data": {
-                    "node": "comma_list",
-                    "comma_list": [
-                      {
-                        "node": "expression",
-                        "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_LITERAL",
-                        "lhs": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_STR",
-                          "data": "Hello, world!"
-                        },
-                        "rhs_type": "EXPR_TYPE_NULL",
-                        "rhs": null,
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      },
-                      {
-                        "node": "expression",
-                        "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
-                        "lhs": {
-                          "node": "identifier",
-                          "identifier_name": "lf"
-                        },
-                        "rhs_type": "EXPR_TYPE_NULL",
-                        "rhs": null,
-                        "condition_type": "EXPR_TYPE_NULL",
-                        "condition": null
-                      }
-                    ]
-                  }
+                  "type": "DATA_TYPE_I64",
+                  "data": 1
                 },
                 "condition_type": "EXPR_TYPE_NULL",
                 "condition": null
               }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 11,
+            "type": "STATEMENT_TYPE_COMPOUND",
+            "statement": {
+              "node": "for_block",
+              "type": "FORBLOCK_TYPE_LIST",
+              "iter": {
+                "node": "identifier",
+                "identifier_name": "x"
+              },
+              "iterable": {
+                "node": "expression",
+                "op": "NOP",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                "lhs": {
+                  "node": "identifier",
+                  "identifier_name": "times"
+                },
+                "rhs_type": "EXPR_TYPE_NULL",
+                "rhs": null,
+                "condition_type": "EXPR_TYPE_NULL",
+                "condition": null
+              },
+              "statements": {
+                "node": "statements",
+                "statements": [
+                  {
+                    "node": "statement",
+                    "line_no": 6,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": null,
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "print"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "$[]",
+                                "lhs_type": "EXPR_TYPE_NULL",
+                                "lhs": null,
+                                "rhs_type": "EXPR_TYPE_LITERAL",
+                                "rhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_I64",
+                                  "data": 1
+                                },
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  },
+                  {
+                    "node": "statement",
+                    "line_no": 7,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": {
+                        "node": "identifier",
+                        "identifier_name": "name"
+                      },
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "input"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "Enter name {x}: "
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs": {
+                                  "node": "identifier",
+                                  "identifier_name": "str"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  },
+                  {
+                    "node": "statement",
+                    "line_no": 9,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": {
+                        "node": "identifier",
+                        "identifier_name": "bytes"
+                      },
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "print"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "Hello {name}!"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "It's a beautiful world!"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs": {
+                                  "node": "identifier",
+                                  "identifier_name": "lf"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  },
+                  {
+                    "node": "statement",
+                    "line_no": 10,
+                    "type": "STATEMENT_TYPE_ASSIGNMENT",
+                    "statement": {
+                      "node": "assignment",
+                      "lhs": null,
+                      "rhs": {
+                        "node": "expression",
+                        "op": "()",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                        "lhs": {
+                          "node": "identifier",
+                          "identifier_name": "print"
+                        },
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_LST",
+                          "data": {
+                            "node": "comma_list",
+                            "comma_list": [
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_LITERAL",
+                                "lhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "Printed: {bytes} Bytes"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs": {
+                                  "node": "identifier",
+                                  "identifier_name": "lf"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              },
+                              {
+                                "node": "expression",
+                                "op": "NOP",
+                                "lhs_type": "EXPR_TYPE_IDENTIFIER",
+                                "lhs": {
+                                  "node": "identifier",
+                                  "identifier_name": "lf"
+                                },
+                                "rhs_type": "EXPR_TYPE_NULL",
+                                "rhs": null,
+                                "condition_type": "EXPR_TYPE_NULL",
+                                "condition": null
+                              }
+                            ]
+                          }
+                        },
+                        "condition_type": "EXPR_TYPE_NULL",
+                        "condition": null
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "node": "statement",
+            "line_no": 12,
+            "type": "STATEMENT_TYPE_RETURN",
+            "statement": {
+              "node": "expression",
+              "op": "NOP",
+              "lhs_type": "EXPR_TYPE_LITERAL",
+              "lhs": {
+                "node": "literal",
+                "type": "DATA_TYPE_I64",
+                "data": 100
+              },
+              "rhs_type": "EXPR_TYPE_NULL",
+              "rhs": null,
+              "condition_type": "EXPR_TYPE_NULL",
+              "condition": null
             }
           }
         ]

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -1,6 +1,6 @@
 module main
 
-proc test start
+proc xyz start
     print("Hello world!", "lf")
 
     var x = input(i64)


### PR DESCRIPTION
- updated Makefiles: added ast and runtime dirs
- using RT_VarTable_getref_tmpvar instead of RT_VarTable_getref for tmpvars
- na: changed indentation lvl of switch-case
- refactored code that copies fn args into tmpvars
- printing "unimplemented" message for operators
- using RT_Data_destroy instead of manually checking and freeing
- error output fix
- RT_Data_destroy: set data to null
- list append: parent list should take ownership of member data
- list to str: fixed bug: \0 instserted at wrong posn
- RT_VarTable: unified varname validity check in create and getref
- updated fn: RT_VarTable_getref_tmpvar
- RT_VarTable do not handle acc and tmpvars anymore
- added fn to produce typename of data
- improved error reporting
- added a built-in fn typename()
- bugfix: null valued global vars
- updated ast output
