### PR TITLE
lots of bugs fixed

### DIFF
--- a/examples/factorial.txt
+++ b/examples/factorial.txt
@@ -8,9 +8,10 @@ end
 
 # factorial(num)
 proc factorial start
-    if $[0] <= 1 then
+    var n = $0
+    if n <= 1 then
         return 1
     else
-        return $[0] * factorial($[0] - 1)
+        return n * factorial(n - 1)
     end
 end

--- a/examples/fncalls.txt
+++ b/examples/fncalls.txt
@@ -1,0 +1,19 @@
+proc main start
+  var x = [1,2,3,4,5]
+  var a = i64
+  var b = f64
+  var c = 'c'
+  var d = null
+  var e = "xyz"
+  print(
+    typename(x),
+    typename(a),
+    typename(b),
+    typename(c),
+    typename(d),
+    typename(e),
+    lf
+  )
+  var y = 3
+  print($y, lf)
+end

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -7,6 +7,7 @@
 #include "data.h"
 
 #define RT_TMPVAR_CNT (32)
+#define RT_ACC_DATA (RT_VarTable_acc_get()->adr ? RT_VarTable_acc_get()->adr : &RT_VarTable_acc_get()->val)
 
 /** accumulator stores procedure return values
     and also the address from which the value was obtained

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -56,7 +56,7 @@ void RT_VarTable_acc_setval(RT_Data_t val);
 void RT_VarTable_acc_setadr(RT_Data_t *adr);
 
 /** push a new function scope into the stack and store the procedure name and return address */
-void RT_VarTable_push_proc(const char *procname, const AST_Statement_t *ret_addr);
+void RT_VarTable_push_proc(const char *procname);
 
 /** pop the procedure off the stack, return the return address and clear the scope from memory */
 const AST_Statement_t *RT_VarTable_pop_proc();

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -49,8 +49,11 @@ RT_Data_t *RT_VarTable_getref_tmpvar(int tmpvar);
 /** this is used to get the accumulator data and address */
 RT_VarTable_Acc_t *RT_VarTable_acc_get(void);
 
-/** this is used to update the accumulator */
-void RT_VarTable_acc_set(RT_Data_t val, RT_Data_t *adr);
+/** this is used to update the accumulator val, nulls adr */
+void RT_VarTable_acc_setval(RT_Data_t val);
+
+/** this is used to update the accumulator adr, nulls val */
+void RT_VarTable_acc_setadr(RT_Data_t *adr);
 
 /** push a new function scope into the stack and store the procedure name and return address */
 void RT_VarTable_push_proc(const char *procname, const AST_Statement_t *ret_addr);

--- a/include/runtime/vartable.h
+++ b/include/runtime/vartable.h
@@ -59,13 +59,13 @@ void RT_VarTable_acc_setadr(RT_Data_t *adr);
 void RT_VarTable_push_proc(const char *procname);
 
 /** pop the procedure off the stack, return the return address and clear the scope from memory */
-const AST_Statement_t *RT_VarTable_pop_proc();
+RT_Data_t RT_VarTable_pop_proc(void);
 
 /** push a new local scope into the stack */
 void RT_VarTable_push_scope();
 
 /** pop local scope and return result of last expression */
-RT_Data_t RT_VarTable_pop_scope();
+RT_Data_t RT_VarTable_pop_scope(void);
 
 /** clear memory of the vartable */
 void RT_VarTable_destroy();

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -17,6 +17,9 @@ int lex_char_no = 1;
 
 LexToken yylex(void)
 {
+    if (lex_currtok == LEXTOK_NEWLINE)
+        if (yyin == stdin) printf("%s", ">> ");
+
     int token = lex_currtok = lex_get_nexttok(yyin);
     switch (token) {
         case LEXTOK_IDENTIFIER:

--- a/src/parser.y
+++ b/src/parser.y
@@ -424,8 +424,8 @@ postfix_expression:
                                                             AST_Expression_CommaSepList($4), NULL);
                                                         }
     | postfix_expression "[" nws expression "]"         { $$ = AST_Expression(TOKOP_INDEXING, $1, $4, NULL); }
-    | "$" "[" nws expression "]"                        { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $4, NULL); }
-    | "$" "(" nws expression ")"                        { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $4, NULL); }
+    | "$" "[" expression "]"                            { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $3, NULL); }
+    | "$" "(" expression ")"                            { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $3, NULL); }
     | "$" LEXTOK_DECINT_LITERAL                         { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL,
                                                             AST_Expression_Literal(
                                                                 AST_Literal_i64($2)), NULL);

--- a/src/parser.y
+++ b/src/parser.y
@@ -490,6 +490,7 @@ int yyerror(const char* msg)
 void parse_interpret(FILE *f)
 {
     yyin = f;
+    if (yyin == stdin) printf("%s", ">> ");
 #ifdef LEX_DEBUG
     LexToken tok = lex_get_nexttok(yyin);
     while (tok != LEXTOK_EOF) {

--- a/src/parser.y
+++ b/src/parser.y
@@ -430,6 +430,9 @@ postfix_expression:
                                                             AST_Expression_Literal(
                                                                 AST_Literal_i64($2)), NULL);
                                                         }
+    | "$" identifier                                    { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL,
+                                                            AST_Expression_Identifier($2), NULL);
+                                                        }
     | postfix_expression "++"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "--"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "." identifier                 { $$ = AST_Expression($2, $1,

--- a/src/parser.y
+++ b/src/parser.y
@@ -447,7 +447,7 @@ primary_expression:
     ;
 
 comma_list:
-    expression                                          { $$ = AST_CommaSepList(NULL, $1); }
+    expression nws                                      { $$ = AST_CommaSepList(NULL, $1); }
     | expression "," nws                                { $$ = AST_CommaSepList(NULL, $1); }
     | expression "," nws comma_list                     { $$ = AST_CommaSepList($4, $1); }
     ;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -50,7 +50,7 @@ void RT_exec(void)
     const AST_Identifier_t *proc = AST_ProcedureMap_main();
     const AST_Statements_t *code = AST_ProcedureMap_get_code(module, proc);
     rt_currfile = AST_ProcedureMap_get_filename(module, proc);
-    RT_VarTable_push_proc(proc->identifier_name, NULL);
+    RT_VarTable_push_proc(proc->identifier_name);
     rt_Statements_eval(code);
     RT_VarTable_pop_proc();
 }
@@ -490,7 +490,7 @@ void rt_fncall_handler(const AST_Identifier_t *module, const AST_Identifier_t *p
 {
     const AST_Statements_t *code = AST_ProcedureMap_get_code(module, proc);
     if (code) {
-        RT_VarTable_push_proc(proc->identifier_name, NULL);
+        RT_VarTable_push_proc(proc->identifier_name);
         rt_Statements_eval(code);
         RT_VarTable_pop_proc();
         return;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -13,13 +13,11 @@
 #include "runtime/data/list.h"
 #include "runtime/data/string.h"
 #include "runtime/io.h"
+#include "runtime/vartable.h"
 
 #include "runtime/data.c.h"
 #include "runtime/io.c.h"
 #include "runtime/vartable.c.h"
-#include "runtime/vartable.h"
-
-#define RT_ACC_DATA (RT_VarTable_acc_get()->adr ? RT_VarTable_acc_get()->adr : &RT_VarTable_acc_get()->val)
 
 const char *rt_currfile = NULL;
 int rt_currline = 0;

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -270,22 +270,6 @@ void RT_VarTable_destroy()
     return;
 }
 
-void RT_VarTable_test()
-{
-    /* push first scope */
-    RT_VarTable_push_proc("main", NULL);
-    /* set a variable in the current scope */
-    RT_Data_t var1 = RT_Data_i64(42);
-    RT_VarTable_create("var1", var1);
-    /* get a variable from the current scope */
-    RT_Data_t var1_ = *RT_VarTable_getref("var1");
-    if (!RT_Data_isnull(var1_))
-        RT_Data_print(var1_);
-    /* pop the current scope */
-    RT_VarTable_pop_proc();
-    RT_VarTable_destroy();
-}
-
 #else
     #warning re-inclusion of module 'runtime/vartable.c.h'
 #endif

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -122,13 +122,14 @@ RT_Data_t *RT_VarTable_getref(const char *varname)
         RT_Data_t *globvar = rt_vtable_get_globvar(varname);
         if (globvar) return globvar;
     }
-    RT_VarTable_Proc_t *current_proc = &(rt_vtable->procs[rt_vtable->top]);
-    for (int64_t i = current_proc->top; i >= 0; i--) {
+    RT_VarTable_Proc_t *current_proc = &(rt_vtable->procs[rt_vtable->curr_proc_ptr]);
+    /* go down the scopes stack to find the right local variable */
+    for (int64_t i = current_proc->curr_scope_ptr; i >= 0; i--) {
         RT_VarTable_Scope_t *current_scope = &(current_proc->scopes[i]);
-        khiter_t iter = kh_get(RT_Data_t, current_scope->scope, varname);
+        khiter_t entry_it = kh_get(RT_Data_t, current_scope->var_map, varname);
         /* variable found, return its value */
-        if (iter != kh_end(current_scope->scope)) {
-            return &kh_value(current_scope->scope, iter);
+        if (entry_it != kh_end(current_scope->var_map)) {
+            return &kh_value(current_scope->var_map, entry_it);
         }
     }
     /* variable not found, throw an error */

--- a/src/runtime/vartable.c.h
+++ b/src/runtime/vartable.c.h
@@ -21,34 +21,33 @@ KHASH_MAP_INIT_STR(RT_Data_t, RT_Data_t)
 
 /** local scope, stores a map of variables */
 typedef struct {
-    khash_t(RT_Data_t) *scope;
+    khash_t(RT_Data_t) *var_map;
 } RT_VarTable_Scope_t;
 
-/** scope of a procedure that stores local scopes,
-    return address of last procedure and name of
-    the current procedure */
+/** the scopes stack of a procedure */
 typedef struct {
     RT_VarTable_Scope_t *scopes;
-    int64_t top;
+    int64_t curr_scope_ptr;
     size_t capacity;
-    const char *procname;
-    const AST_Statement_t *ret_addr;
 } RT_VarTable_Proc_t;
 
+/** the VarTable is basically the call stack */
 typedef struct {
     RT_VarTable_Proc_t *procs;
-    int64_t top;
+    int64_t curr_proc_ptr;
     size_t capacity;
 } RT_VarTable_t;
 
 /** gloablly allocated stack pointer */
 RT_VarTable_t *rt_vtable = NULL;
 
+/** the accumulator */
 RT_VarTable_Acc_t rt_vtable_accumulator = {
     .val = { .data.any = NULL, RT_DATA_TYPE_ANY },
     .adr = NULL
 };
 
+/** an array of 32 tmp variables */
 RT_Data_t rt_vtable_tmpvars[RT_TMPVAR_CNT];
 
 /* few globally defined variables */


### PR DESCRIPTION
- moved RC_ACC_DATA to runtime/vartable.h
- added acc get fn in runtime/vartable.h
- push_proc does not require statement addr
- pop_proc and pop_scope take void and return RT_Data_t i.e. *RT_ACC_DATA
- vartable.c.h: renamed and refactored members
- vartable.c.h: moved posn of push_proc and push_scope; pop_scope does not pop_proc any more
- copy data before destroy
- getref: refactored
- rm RT_VarTable_test
- added indicators for term io
- bug tmp fix: fn args are passed properly
- rm need for nws in $[] and $()
- added nws for multiline wriiten without trailing comma lists
- $ works directly with identifiers
- updated examples
