### PR TITLE
added support forhash maps

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -16,6 +16,7 @@ typedef struct AST_Block_t                AST_Block_t;
 typedef struct AST_Expression_t           AST_Expression_t;
 typedef struct AST_Expression_t           AST_Condition_t;
 typedef struct AST_CommaSepList_t         AST_CommaSepList_t;
+typedef struct AST_AssociativeList_t      AST_AssociativeList_t;
 
 typedef struct AST_Literal_t              AST_Literal_t;
 typedef struct AST_Identifier_t           AST_Identifier_t;

--- a/include/ast/api.h
+++ b/include/ast/api.h
@@ -124,7 +124,7 @@ struct AST_CommaSepList_t {
 };
 
 struct AST_AssociativeList_t {
-    AST_CommaSepList_t *assoc_list;
+    AST_AssociativeList_t *assoc_list;
     AST_Literal_t *key;
     AST_Expression_t *value;
 };

--- a/include/ast/api.h
+++ b/include/ast/api.h
@@ -123,14 +123,21 @@ struct AST_CommaSepList_t {
     const AST_Expression_t *expression;
 };
 
+struct AST_AssociativeList_t {
+    AST_CommaSepList_t *assoc_list;
+    AST_Literal_t *key;
+    AST_Expression_t *value;
+};
+
 struct AST_Literal_t {
-    const union {
+    union {
         const bool bul;
         const char chr;
         const int64_t i64;
         const double f64;
         const char *str;
         const AST_CommaSepList_t *lst;
+        const AST_AssociativeList_t *mp;
         const void *any;
     }  data;
     const enum AST_DataType_t type;

--- a/include/ast/nodes.h
+++ b/include/ast/nodes.h
@@ -113,6 +113,12 @@ struct AST_CommaSepList_t {
     AST_Expression_t *expression;
 };
 
+struct AST_AssociativeList_t {
+    AST_CommaSepList_t *assoc_list;
+    AST_Literal_t *key;
+    AST_Expression_t *value;
+};
+
 struct AST_Literal_t {
     union {
         bool bul;
@@ -121,6 +127,7 @@ struct AST_Literal_t {
         double f64;
         char *str;
         AST_CommaSepList_t *lst;
+        AST_AssociativeList_t *mp;
         void *any;
     }  data;
     enum AST_DataType_t type;

--- a/include/ast/nodes.h
+++ b/include/ast/nodes.h
@@ -114,7 +114,7 @@ struct AST_CommaSepList_t {
 };
 
 struct AST_AssociativeList_t {
-    AST_CommaSepList_t *assoc_list;
+    AST_AssociativeList_t *assoc_list;
     AST_Literal_t *key;
     AST_Expression_t *value;
 };

--- a/include/ast/nodes/create.h
+++ b/include/ast/nodes/create.h
@@ -37,7 +37,7 @@ AST_Expression_t    *AST_Expression_Identifier(AST_Identifier_t *identifier);
 AST_Expression_t    *AST_Expression_CommaSepList(AST_CommaSepList_t *comma_list);
 
 AST_CommaSepList_t  *AST_CommaSepList(AST_CommaSepList_t *comma_list, AST_Expression_t *expression);
-AST_AssociativeList_t  *AST_CommaSepList(AST_AssociativeList_t *assoc_list, AST_Literal_t *key, AST_Expression_t *value);
+AST_AssociativeList_t  *AST_AssociativeList(AST_AssociativeList_t *assoc_list, AST_Literal_t *key, AST_Expression_t *value);
 
 AST_Literal_t       *AST_Literal_bul(bool literal);
 AST_Literal_t       *AST_Literal_chr(char literal);

--- a/include/ast/nodes/create.h
+++ b/include/ast/nodes/create.h
@@ -37,6 +37,7 @@ AST_Expression_t    *AST_Expression_Identifier(AST_Identifier_t *identifier);
 AST_Expression_t    *AST_Expression_CommaSepList(AST_CommaSepList_t *comma_list);
 
 AST_CommaSepList_t  *AST_CommaSepList(AST_CommaSepList_t *comma_list, AST_Expression_t *expression);
+AST_AssociativeList_t  *AST_CommaSepList(AST_AssociativeList_t *assoc_list, AST_Literal_t *key, AST_Expression_t *value);
 
 AST_Literal_t       *AST_Literal_bul(bool literal);
 AST_Literal_t       *AST_Literal_chr(char literal);
@@ -45,6 +46,7 @@ AST_Literal_t       *AST_Literal_i64(int64_t literal);
 AST_Literal_t       *AST_Literal_str(char *literal);
 AST_Literal_t       *AST_Literal_interp_str(char *literal);
 AST_Literal_t       *AST_Literal_lst(AST_CommaSepList_t *literal);
+AST_Literal_t       *AST_Literal_map(AST_AssociativeList_t *literal);
 
 AST_Identifier_t    *AST_Identifier(char *identifier_name);
 

--- a/include/ast/nodes/destroy.h
+++ b/include/ast/nodes/destroy.h
@@ -14,6 +14,7 @@ void AST_ForBlock_free(AST_ForBlock_t **ptr);
 void AST_Block_free(AST_Block_t **ptr);
 void AST_Expression_free(AST_Expression_t **ptr);
 void AST_CommaSepList_free(AST_CommaSepList_t **ptr);
+void AST_AssociativeList_free(AST_AssociativeList_t **ptr);
 void AST_Literal_free(AST_Literal_t **ptr);
 void AST_Identifier_free(AST_Identifier_t **ptr);
 

--- a/include/ast/nodes/enums.h
+++ b/include/ast/nodes/enums.h
@@ -46,6 +46,7 @@ enum AST_DataType_t {
     DATA_TYPE_INTERP_STR = 5, /* parsable char* : variable  */
     DATA_TYPE_LST = 6,        /* linked list    : variable  */
     DATA_TYPE_ANY = 7,        /* void*          : undefined */
+    DATA_TYPE_MAP = 8,        /* hash map       : variable */
 };
 
 #endif

--- a/include/ast2json.h
+++ b/include/ast2json.h
@@ -15,6 +15,7 @@ void AST2JSON_ForBlock(const AST_ForBlock_t* for_block);
 void AST2JSON_Block(const AST_Block_t* block);
 void AST2JSON_Expression(const AST_Expression_t* expression);
 void AST2JSON_CommaSepList(const AST_CommaSepList_t* comma_list);
+void AST2JSON_AssociativeList(const AST_AssociativeList_t* assoc_list);
 void AST2JSON_Literal(const AST_Literal_t* literal);
 void AST2JSON_Identifier(const AST_Identifier_t* identifier);
 void AST2JSON_ProcedureMap();

--- a/include/runtime/data/map.h
+++ b/include/runtime/data/map.h
@@ -5,7 +5,12 @@
 #include "tlib/khash/khash.h"
 #include "runtime/data.h"
 
-KHASH_MAP_INIT_STR(RT_DataMap_t, RT_Data_t)
+typedef struct {
+    char *key;
+    RT_Data_t value;
+} RT_DataMapEntry_t;
+
+KHASH_MAP_INIT_STR(RT_DataMap_t, RT_DataMapEntry_t)
 
 struct RT_DataMap_t {
     khash_t(RT_DataMap_t) *data_map;

--- a/src/ast/nodes/create.c.h
+++ b/src/ast/nodes/create.c.h
@@ -274,6 +274,16 @@ AST_CommaSepList_t *AST_CommaSepList(AST_CommaSepList_t *comma_list, AST_Express
     return comma_sep_list;
 }
 
+AST_AssociativeList_t *AST_AssociativeList(AST_AssociativeList_t *assoc_list, AST_Literal_t *key, AST_Expression_t *value)
+{
+    AST_AssociativeList_t *associative_list = (AST_AssociativeList_t*) malloc(sizeof(AST_AssociativeList_t));
+    if (!associative_list) io_errndie("AST_AssociativeList_t:" ERR_MSG_MALLOCFAIL);
+    associative_list->assoc_list = assoc_list;
+    associative_list->key = key;
+    associative_list->value = value;
+    return associative_list;
+}
+
 AST_Literal_t *AST_Literal_bul(bool literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
@@ -334,6 +344,15 @@ AST_Literal_t *AST_Literal_lst(AST_CommaSepList_t *literal)
     if (!ast_literal) io_errndie("AST_Literal_lst:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_LST;
     ast_literal->data.lst = literal;
+    return ast_literal;
+}
+
+AST_Literal_t *AST_Literal_map(AST_AssociativeList_t *literal)
+{
+    AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
+    if (!ast_literal) io_errndie("AST_Literal_map:" ERR_MSG_MALLOCFAIL);
+    ast_literal->type = DATA_TYPE_MAP;
+    ast_literal->data.mp = literal;
     return ast_literal;
 }
 

--- a/src/ast/nodes/create.c.h
+++ b/src/ast/nodes/create.c.h
@@ -10,7 +10,7 @@
 AST_Statements_t *AST_Statements(AST_Statements_t *statements, AST_Statement_t *statement)
 {
     AST_Statements_t *stmts = (AST_Statements_t*) malloc(sizeof(AST_Statements_t));
-    if (!stmts) io_errndie("AST_Statements: " ERR_MSG_MALLOCFAIL);
+    if (!stmts) io_errndie("AST_Statements:" ERR_MSG_MALLOCFAIL);
     stmts->statements = statements;
     stmts->statement = statement;
     return stmts;
@@ -18,7 +18,7 @@ AST_Statements_t *AST_Statements(AST_Statements_t *statements, AST_Statement_t *
 
 AST_Statement_t *AST_Statement_empty(int line_no) {
     AST_Statement_t *stmt = (AST_Statement_t*) malloc(sizeof(AST_Statement_t));
-    if (!stmt) io_errndie("AST_Statement_empty: " ERR_MSG_MALLOCFAIL);
+    if (!stmt) io_errndie("AST_Statement_empty:" ERR_MSG_MALLOCFAIL);
     stmt->type = STATEMENT_TYPE_EMPTY;
     stmt->statement.assignment = NULL;
     stmt->line_no = line_no;
@@ -28,7 +28,7 @@ AST_Statement_t *AST_Statement_empty(int line_no) {
 AST_Statement_t *AST_Statement_return(AST_Expression_t *expression, int line_no)
 {
     AST_Statement_t *stmt = (AST_Statement_t*) malloc(sizeof(AST_Statement_t));
-    if (!stmt) io_errndie("AST_Statement_return: " ERR_MSG_MALLOCFAIL);
+    if (!stmt) io_errndie("AST_Statement_return:" ERR_MSG_MALLOCFAIL);
     stmt->type = STATEMENT_TYPE_RETURN;
     stmt->statement.expression = expression;
     stmt->line_no = line_no;
@@ -38,7 +38,7 @@ AST_Statement_t *AST_Statement_return(AST_Expression_t *expression, int line_no)
 AST_Statement_t *AST_Statement_Assignment(AST_Assignment_t *assignment, int line_no)
 {
     AST_Statement_t *stmt = (AST_Statement_t*) malloc(sizeof(AST_Statement_t));
-    if (!stmt) io_errndie("AST_Statement_Assignment: " ERR_MSG_MALLOCFAIL);
+    if (!stmt) io_errndie("AST_Statement_Assignment:" ERR_MSG_MALLOCFAIL);
     stmt->type = STATEMENT_TYPE_ASSIGNMENT;
     stmt->statement.assignment = assignment;
     stmt->line_no = line_no;
@@ -48,7 +48,7 @@ AST_Statement_t *AST_Statement_Assignment(AST_Assignment_t *assignment, int line
 AST_Statement_t *AST_Statement_CompoundSt(AST_CompoundSt_t *compound, int line_no)
 {
     AST_Statement_t *stmt = (AST_Statement_t*) malloc(sizeof(AST_Statement_t));
-    if (!stmt) io_errndie("AST_Statement_CompoundSt: " ERR_MSG_MALLOCFAIL);
+    if (!stmt) io_errndie("AST_Statement_CompoundSt:" ERR_MSG_MALLOCFAIL);
     stmt->type = STATEMENT_TYPE_COMPOUND;
     stmt->statement.compound_statement = compound;
     stmt->line_no = line_no;
@@ -58,7 +58,7 @@ AST_Statement_t *AST_Statement_CompoundSt(AST_CompoundSt_t *compound, int line_n
 AST_Assignment_t *AST_Assignment_create(AST_Identifier_t *identifier, AST_Expression_t *expression)
 {
     AST_Assignment_t *assign = (AST_Assignment_t*) malloc(sizeof(AST_Assignment_t));
-    if (!assign) io_errndie("AST_Assignment_create: " ERR_MSG_MALLOCFAIL);
+    if (!assign) io_errndie("AST_Assignment_create:" ERR_MSG_MALLOCFAIL);
     assign->lhs = identifier;
     assign->rhs = expression;
     assign->type = ASSIGNMENT_TYPE_CREATE;
@@ -68,7 +68,7 @@ AST_Assignment_t *AST_Assignment_create(AST_Identifier_t *identifier, AST_Expres
 AST_Assignment_t *AST_Assignment_tovoid(AST_Expression_t *expression)
 {
     AST_Assignment_t *assign = (AST_Assignment_t*) malloc(sizeof(AST_Assignment_t));
-    if (!assign) io_errndie("AST_Assignment_tovoid: " ERR_MSG_MALLOCFAIL);
+    if (!assign) io_errndie("AST_Assignment_tovoid:" ERR_MSG_MALLOCFAIL);
     assign->lhs = NULL;
     assign->rhs = expression;
     assign->type = ASSIGNMENT_TYPE_TOVOID;
@@ -78,7 +78,7 @@ AST_Assignment_t *AST_Assignment_tovoid(AST_Expression_t *expression)
 AST_CompoundSt_t *AST_CompoundSt_IfBlock(AST_IfBlock_t *block)
 {
     AST_CompoundSt_t *compound = (AST_CompoundSt_t*) malloc(sizeof(AST_CompoundSt_t));
-    if (!compound) io_errndie("AST_CompoundSt_IfBlock: " ERR_MSG_MALLOCFAIL);
+    if (!compound) io_errndie("AST_CompoundSt_IfBlock:" ERR_MSG_MALLOCFAIL);
     compound->type = COMPOUNDST_TYPE_IF;
     compound->compound_statement.if_block = block;
     return compound;
@@ -87,7 +87,7 @@ AST_CompoundSt_t *AST_CompoundSt_IfBlock(AST_IfBlock_t *block)
 AST_CompoundSt_t *AST_CompoundSt_WhileBlock(AST_WhileBlock_t *block)
 {
     AST_CompoundSt_t *compound = (AST_CompoundSt_t*) malloc(sizeof(AST_CompoundSt_t));
-    if (!compound) io_errndie("AST_CompoundSt_WhileBlock: " ERR_MSG_MALLOCFAIL);
+    if (!compound) io_errndie("AST_CompoundSt_WhileBlock:" ERR_MSG_MALLOCFAIL);
     compound->type = COMPOUNDST_TYPE_WHILE;
     compound->compound_statement.while_block = block;
     return compound;
@@ -96,7 +96,7 @@ AST_CompoundSt_t *AST_CompoundSt_WhileBlock(AST_WhileBlock_t *block)
 AST_CompoundSt_t *AST_CompoundSt_ForBlock(AST_ForBlock_t *block)
 {
     AST_CompoundSt_t *compound = (AST_CompoundSt_t*) malloc(sizeof(AST_CompoundSt_t));
-    if (!compound) io_errndie("AST_CompoundSt_ForBlock: " ERR_MSG_MALLOCFAIL);
+    if (!compound) io_errndie("AST_CompoundSt_ForBlock:" ERR_MSG_MALLOCFAIL);
     compound->type = COMPOUNDST_TYPE_FOR;
     compound->compound_statement.for_block = block;
     return compound;
@@ -105,7 +105,7 @@ AST_CompoundSt_t *AST_CompoundSt_ForBlock(AST_ForBlock_t *block)
 AST_CompoundSt_t *AST_CompoundSt_Block(AST_Block_t *block)
 {
     AST_CompoundSt_t *compound = (AST_CompoundSt_t*) malloc(sizeof(AST_CompoundSt_t));
-    if (!compound) io_errndie("AST_CompoundSt_Block: " ERR_MSG_MALLOCFAIL);
+    if (!compound) io_errndie("AST_CompoundSt_Block:" ERR_MSG_MALLOCFAIL);
     compound->type = COMPOUNDST_TYPE_BLOCK;
     compound->compound_statement.block = block;
     return compound;
@@ -114,7 +114,7 @@ AST_CompoundSt_t *AST_CompoundSt_Block(AST_Block_t *block)
 AST_IfBlock_t *AST_IfBlock(AST_Condition_t *condition, AST_Statements_t *if_st, AST_ElseBlock_t *else_block)
 {
     AST_IfBlock_t *if_block = (AST_IfBlock_t*) malloc(sizeof(AST_IfBlock_t));
-    if (!if_block) io_errndie("AST_IfBlock: " ERR_MSG_MALLOCFAIL);
+    if (!if_block) io_errndie("AST_IfBlock:" ERR_MSG_MALLOCFAIL);
     if_block->condition = condition;
     if_block->if_st = if_st;
     if_block->else_block = else_block;
@@ -124,7 +124,7 @@ AST_IfBlock_t *AST_IfBlock(AST_Condition_t *condition, AST_Statements_t *if_st, 
 AST_ElseBlock_t *AST_ElseBlock(AST_Condition_t *condition, AST_Statements_t *else_if_st, AST_ElseBlock_t *else_block)
 {
     AST_ElseBlock_t *block = (AST_ElseBlock_t*) malloc(sizeof(AST_ElseBlock_t));
-    if (!block) io_errndie("AST_ElseBlock: " ERR_MSG_MALLOCFAIL);
+    if (!block) io_errndie("AST_ElseBlock:" ERR_MSG_MALLOCFAIL);
     block->condition = condition;
     block->else_if_st = else_if_st;
     block->else_block = else_block;
@@ -134,7 +134,7 @@ AST_ElseBlock_t *AST_ElseBlock(AST_Condition_t *condition, AST_Statements_t *els
 AST_WhileBlock_t *AST_WhileBlock(AST_Condition_t *condition, AST_Statements_t *while_st)
 {
     AST_WhileBlock_t *while_block = (AST_WhileBlock_t*) malloc(sizeof(AST_WhileBlock_t));
-    if (!while_block) io_errndie("AST_WhileBlock: " ERR_MSG_MALLOCFAIL);
+    if (!while_block) io_errndie("AST_WhileBlock:" ERR_MSG_MALLOCFAIL);
     while_block->condition = condition;
     while_block->statements = while_st;
     return while_block;
@@ -143,7 +143,7 @@ AST_WhileBlock_t *AST_WhileBlock(AST_Condition_t *condition, AST_Statements_t *w
 AST_ForBlock_t *AST_ForBlock(AST_Identifier_t *iter, AST_Expression_t *start, AST_Expression_t *end, AST_Expression_t *by, AST_Statements_t *for_st)
 {
     AST_ForBlock_t *for_block = (AST_ForBlock_t*) malloc(sizeof(AST_ForBlock_t));
-    if (!for_block) io_errndie("AST_ForBlock: " ERR_MSG_MALLOCFAIL);
+    if (!for_block) io_errndie("AST_ForBlock:" ERR_MSG_MALLOCFAIL);
     for_block->iter = iter;
     for_block->iterable.range.start = start;
     for_block->iterable.range.end = end;
@@ -156,7 +156,7 @@ AST_ForBlock_t *AST_ForBlock(AST_Identifier_t *iter, AST_Expression_t *start, AS
 AST_ForBlock_t *AST_ForBlock_iterate(AST_Identifier_t *iter, AST_Expression_t *lst, AST_Statements_t *for_st)
 {
     AST_ForBlock_t *for_block = (AST_ForBlock_t*) malloc(sizeof(AST_ForBlock_t));
-    if (!for_block) io_errndie("AST_ForBlock_iterate: " ERR_MSG_MALLOCFAIL);
+    if (!for_block) io_errndie("AST_ForBlock_iterate:" ERR_MSG_MALLOCFAIL);
     for_block->iter = iter;
     for_block->iterable.lst = lst;
     for_block->statements = for_st;
@@ -167,7 +167,7 @@ AST_ForBlock_t *AST_ForBlock_iterate(AST_Identifier_t *iter, AST_Expression_t *l
 AST_Block_t *AST_Block(AST_Statements_t *statements)
 {
     AST_Block_t *block = (AST_Block_t*) malloc(sizeof(AST_Block_t));
-    if (!block) io_errndie("AST_Block: " ERR_MSG_MALLOCFAIL);
+    if (!block) io_errndie("AST_Block:" ERR_MSG_MALLOCFAIL);
     block->statements = statements;
     return block;
 }
@@ -184,7 +184,7 @@ AST_Block_t *AST_Block(AST_Statements_t *statements)
 AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_Expression_t *rhs, AST_Expression_t *condition)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
-    if (!expression) io_errndie("AST_Expression: " ERR_MSG_MALLOCFAIL);
+    if (!expression) io_errndie("AST_Expression:" ERR_MSG_MALLOCFAIL);
     expression->op = op;
 
     if (AST_EXPRESSION_ISOPERAND(lhs)) {
@@ -226,7 +226,7 @@ AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_E
 AST_Expression_t *AST_Expression_Literal(AST_Literal_t *literal)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
-    if (!expression) io_errndie("AST_Expression_Literal: " ERR_MSG_MALLOCFAIL);
+    if (!expression) io_errndie("AST_Expression_Literal:" ERR_MSG_MALLOCFAIL);
     expression->op = TOKOP_NOP;
     expression->lhs_type = EXPR_TYPE_LITERAL;
     expression->lhs.literal = literal;
@@ -240,7 +240,7 @@ AST_Expression_t *AST_Expression_Literal(AST_Literal_t *literal)
 AST_Expression_t *AST_Expression_Identifier(AST_Identifier_t *identifier)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
-    if (!expression) io_errndie("AST_Expression_Identifier: " ERR_MSG_MALLOCFAIL);
+    if (!expression) io_errndie("AST_Expression_Identifier:" ERR_MSG_MALLOCFAIL);
     expression->op = TOKOP_NOP;
     expression->lhs_type = EXPR_TYPE_IDENTIFIER;
     expression->lhs.variable = identifier;
@@ -254,7 +254,7 @@ AST_Expression_t *AST_Expression_Identifier(AST_Identifier_t *identifier)
 AST_Expression_t *AST_Expression_CommaSepList(AST_CommaSepList_t *comma_list)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
-    if (!expression) io_errndie("AST_Expression_CommaSepList: " ERR_MSG_MALLOCFAIL);
+    if (!expression) io_errndie("AST_Expression_CommaSepList:" ERR_MSG_MALLOCFAIL);
     expression->op = TOKOP_NOP;
     expression->lhs_type = EXPR_TYPE_LITERAL;
     expression->lhs.literal = AST_Literal_lst(comma_list);
@@ -268,7 +268,7 @@ AST_Expression_t *AST_Expression_CommaSepList(AST_CommaSepList_t *comma_list)
 AST_CommaSepList_t *AST_CommaSepList(AST_CommaSepList_t *comma_list, AST_Expression_t *expression)
 {
     AST_CommaSepList_t *comma_sep_list = (AST_CommaSepList_t*) malloc(sizeof(AST_CommaSepList_t));
-    if (!comma_sep_list) io_errndie("AST_CommaSepList: " ERR_MSG_MALLOCFAIL);
+    if (!comma_sep_list) io_errndie("AST_CommaSepList:" ERR_MSG_MALLOCFAIL);
     comma_sep_list->comma_list = comma_list;
     comma_sep_list->expression = expression;
     return comma_sep_list;
@@ -277,7 +277,7 @@ AST_CommaSepList_t *AST_CommaSepList(AST_CommaSepList_t *comma_list, AST_Express
 AST_Literal_t *AST_Literal_bul(bool literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_bul: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_bul:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_BUL;
     ast_literal->data.bul = literal;
     return ast_literal;
@@ -286,7 +286,7 @@ AST_Literal_t *AST_Literal_bul(bool literal)
 AST_Literal_t *AST_Literal_chr(char literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_chr: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_chr:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_CHR;
     ast_literal->data.chr = literal;
     return ast_literal;
@@ -295,7 +295,7 @@ AST_Literal_t *AST_Literal_chr(char literal)
 AST_Literal_t *AST_Literal_f64(double literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_f64: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_f64:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_F64;
     ast_literal->data.f64 = literal;
     return ast_literal;
@@ -304,7 +304,7 @@ AST_Literal_t *AST_Literal_f64(double literal)
 AST_Literal_t *AST_Literal_i64(int64_t literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_i64: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_i64:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_I64;
     ast_literal->data.i64 = literal;
     return ast_literal;
@@ -313,7 +313,7 @@ AST_Literal_t *AST_Literal_i64(int64_t literal)
 AST_Literal_t *AST_Literal_str(char *literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_str: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_str:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_STR;
     ast_literal->data.str = literal;
     return ast_literal;
@@ -322,7 +322,7 @@ AST_Literal_t *AST_Literal_str(char *literal)
 AST_Literal_t *AST_Literal_interp_str(char *literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_interp_str: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_interp_str:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_INTERP_STR;
     ast_literal->data.str = literal;
     return ast_literal;
@@ -331,7 +331,7 @@ AST_Literal_t *AST_Literal_interp_str(char *literal)
 AST_Literal_t *AST_Literal_lst(AST_CommaSepList_t *literal)
 {
     AST_Literal_t *ast_literal = (AST_Literal_t*) malloc(sizeof(AST_Literal_t));
-    if (!ast_literal) io_errndie("AST_Literal_lst: " ERR_MSG_MALLOCFAIL);
+    if (!ast_literal) io_errndie("AST_Literal_lst:" ERR_MSG_MALLOCFAIL);
     ast_literal->type = DATA_TYPE_LST;
     ast_literal->data.lst = literal;
     return ast_literal;
@@ -340,7 +340,7 @@ AST_Literal_t *AST_Literal_lst(AST_CommaSepList_t *literal)
 AST_Identifier_t *AST_Identifier(char *identifier_name)
 {
     AST_Identifier_t *identifier = (AST_Identifier_t*) malloc(sizeof(AST_Identifier_t));
-    if (!identifier) io_errndie("AST_Identifier: " ERR_MSG_MALLOCFAIL);
+    if (!identifier) io_errndie("AST_Identifier:" ERR_MSG_MALLOCFAIL);
     identifier->identifier_name = identifier_name;
     return identifier;
 }

--- a/src/ast/nodes/destroy.c.h
+++ b/src/ast/nodes/destroy.c.h
@@ -193,10 +193,26 @@ void AST_CommaSepList_free(AST_CommaSepList_t **ptr)
 {
     if (!ptr) return;
     AST_CommaSepList_t *comma_list = *ptr;
-    if (!comma_list) return;
-    AST_CommaSepList_free(&comma_list->comma_list);
-    AST_Expression_free(&comma_list->expression);
-    free(comma_list);
+    while (comma_list) {
+        AST_Expression_free(&comma_list->expression);
+        AST_CommaSepList_t *rm = comma_list;
+        comma_list = comma_list->comma_list;
+        free(rm);
+    }
+    *ptr = NULL;
+}
+
+void AST_AssociativeList_free(AST_AssociativeList_t **ptr)
+{
+    if (!ptr) return;
+    AST_AssociativeList_t *assoc_list = *ptr;
+    while (assoc_list) {
+        AST_Literal_free(&assoc_list->key);
+        AST_Expression_free(&assoc_list->value);
+        AST_AssociativeList_t *rm = assoc_list;
+        assoc_list = assoc_list->assoc_list;
+        free(rm);
+    }
     *ptr = NULL;
 }
 
@@ -212,6 +228,9 @@ void AST_Literal_free(AST_Literal_t **ptr)
             break;
         case DATA_TYPE_LST:
             AST_CommaSepList_free(&literal->data.lst);
+            break;
+        case DATA_TYPE_MAP:
+            AST_AssociativeList_free(&literal->data.mp);
             break;
         default: break;
     }

--- a/src/ast2json.c
+++ b/src/ast2json.c
@@ -524,6 +524,46 @@ void AST2JSON_CommaSepList(const AST_CommaSepList_t *comma_list)
     AST2JSON_close_obj();
 }
 
+void AST2JSON_AssociativeList(const AST_AssociativeList_t* assoc_list)
+{
+    if (!assoc_list) {
+        AST2JSON_printf("null");
+        return;
+    }
+
+    AST2JSON_open_obj();
+    AST2JSON_printf("\"node\": \"assoc_list\"");
+
+    const AST_AssociativeList_t *mp = assoc_list;
+    AST2JSON_put_comma();
+    AST2JSON_printf("\"assoc_list\": ");
+    AST2JSON_open_list();
+
+    AST2JSON_open_obj();
+    AST2JSON_printf("\"key\": ");
+    AST2JSON_Literal(mp->key);
+    AST2JSON_put_comma();
+    AST2JSON_printf("\"value\": ");
+    AST2JSON_Expression(mp->value);
+    AST2JSON_close_obj();
+
+    mp = mp->assoc_list;
+
+    while (mp) {
+        AST2JSON_open_obj();
+        AST2JSON_printf("\"key\": ");
+        AST2JSON_Literal(mp->key);
+        AST2JSON_put_comma();
+        AST2JSON_printf("\"value\": ");
+        AST2JSON_Expression(mp->value);
+        AST2JSON_close_obj();
+        mp = mp->assoc_list;
+    }
+
+    AST2JSON_close_list();
+    AST2JSON_close_obj();
+}
+
 /* function to convert AST_Literal_t to JSON */
 void AST2JSON_Literal(const AST_Literal_t *literal)
 {
@@ -593,6 +633,13 @@ void AST2JSON_Literal(const AST_Literal_t *literal)
             AST2JSON_put_comma();
             AST2JSON_printf("\"data\": ");
             AST2JSON_CommaSepList(literal->data.lst);
+            break;
+        case DATA_TYPE_MAP:
+            AST2JSON_put_comma();
+            AST2JSON_printf("\"type\": \"DATA_TYPE_MAP\"");
+            AST2JSON_put_comma();
+            AST2JSON_printf("\"data\": ");
+            AST2JSON_AssociativeList(literal->data.mp);
             break;
         case DATA_TYPE_ANY:
             AST2JSON_put_comma();

--- a/src/parser.y
+++ b/src/parser.y
@@ -428,7 +428,7 @@ postfix_expression:
     | postfix_expression "(" nws comma_list ")"         { $$ = AST_Expression(TOKOP_FNCALL, $1,
                                                             AST_Expression_CommaSepList($4), NULL);
                                                         }
-    | postfix_expression "[" expression "]"             { $$ = AST_Expression(TOKOP_INDEXING, $1, $4, NULL); }
+    | postfix_expression "[" expression "]"             { $$ = AST_Expression(TOKOP_INDEXING, $1, $3, NULL); }
     | "$" "[" expression "]"                            { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $3, NULL); }
     | "$" "(" expression ")"                            { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL, $3, NULL); }
     | "$" LEXTOK_DECINT_LITERAL                         { $$ = AST_Expression(TOKOP_FNARGS_INDEXING, NULL,
@@ -463,7 +463,7 @@ comma_list:
 assoc_list:
     string_literal ":" expression nws                   { $$ = AST_AssociativeList(NULL, $1, $3); }
     | string_literal ":" expression "," nws             { $$ = AST_AssociativeList(NULL, $1, $3); }
-    | string_literal ":" expression "," nws assoc_list  { $$ = AST_AssociativeList($4, $1, $3); }
+    | string_literal ":" expression "," nws assoc_list  { $$ = AST_AssociativeList($6, $1, $3); }
     ;
 
 literal:


### PR DESCRIPTION
- parser.y: seperated composite types into sections
- added syntax for associative lists i.e. maps
- ast: added definitions for map type
- added types to new nodes
- create.c.h: code refactor
- ast: updated headers to introduce associative list
- parser.y: logic bug fix
- ast: added assoc map create and destroy fn
- added support for assoc list in AST2JSON
- runtime: added support for convering assoc list to hash map
- map: fixed memory bug by storing key of map along with value
