### PR TITLE
stack trace support in rt_throw errors

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before you get started, please take a moment to read and follow these guidelines
 - [Naming Conventions](#naming-conventions)
 - [The eval functions](#the-eval-functions)
 - [Memory Management](#memory-management)
-- [Using the `RT_ACC_DATA` macro](#using-the-rt_acc_data-macro)
+- [Using the `RT_VTABLE_ACC` macro](#using-the-rt_acc_data-macro)
 - [Address Sanitizer](#address-sanitizer)
 - [Clangd LSP](#clangd)
 - [Devtools Directory](#devtools-directory)
@@ -82,7 +82,7 @@ The following functions evaluate expressions and **MUST** make a call to either 
 - `rt_eval_CommaSepList`
 - `rt_eval_AssociativeList`
 
-The `RT_ACC_DATA` macro is used to get the accumulator data **ONLY** if one of the above functions was called immediately before.
+The `RT_VTABLE_ACC` macro is used to get the accumulator data **ONLY** if one of the above functions was called immediately before.
 
 ## Memory Management
 If a function can call `free` upon a pointer without any casts and causing no error or warning, the function is said to own it.
@@ -100,7 +100,7 @@ However, be cautious as this can result in poor code quality, so use it judiciou
 For example, a list of `const` struct pointers may be created, but the functions of the list can't free them coz they may still have other references.
 So you may need to explicitly cast to non-`const` and free them from the list only if you're **SURE** that there is no other reference.
 
-## Using the `RT_ACC_DATA` macro
+## Using the `RT_VTABLE_ACC` macro
 Definitiion
 ```
 rt_VarTable_acc_get()->adr

--- a/examples/factorial.txt
+++ b/examples/factorial.txt
@@ -1,7 +1,11 @@
 module main
 
+proc input start
+    return io:input($0, $1)
+end
+
 proc main start
-    var inp = io:input("Enter a number: ", i64)
+    var inp = input("Enter a number: ", i64)
     var res = factorial(inp)
     io:print(f"result = {res}\n")
 end

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -5,12 +5,6 @@
 #include "lexer.h"
 #include "runtime/data/Data.h"
 
-extern const char *rt_currfile;
-extern int rt_currline;
-
-const ast_Identifier_t *rt_modulename_get(void);
-const ast_Identifier_t *rt_procname_get(void);
-
 int rt_exec(int argc, char **argv);
 
 #endif

--- a/include/runtime/VarTable.h
+++ b/include/runtime/VarTable.h
@@ -1,7 +1,10 @@
 #ifndef RT_VARTABLE_H
 #define RT_VARTABLE_H
 
+#include <ctype.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include "ast.h"
 #include "runtime/data/Data.h"
@@ -11,14 +14,40 @@
 #define RT_DEFAULT_CALL_STACK_LIMIT (1000)
 #define RT_ACC_DATA (rt_VarTable_acc_get()->adr ? rt_VarTable_acc_get()->adr : &rt_VarTable_acc_get()->val)
 
+
+typedef rt_DataMap_t *rt_VarTable_Scope_t;
+typedef struct rt_VarTable_proc_t rt_VarTable_proc_t;
+typedef struct rt_VarTable_t rt_VarTable_t;
+typedef struct rt_VarTable_Acc_t rt_VarTable_Acc_t;
+
+
+/** the VarTable is basically the call stack */
+struct rt_VarTable_t {
+    rt_VarTable_proc_t *procs;
+    int64_t curr_proc_ptr;
+    size_t capacity;
+};
+
+/** the scopes stack of a procedure */
+struct rt_VarTable_proc_t {
+    rt_VarTable_Scope_t *scopes;
+    int64_t curr_scope_ptr;
+    size_t capacity;
+    /* info for stack trace */
+    const ast_Identifier_t *modulename;
+    const ast_Identifier_t *procname;
+    const char *filepath;
+    int current_line;
+};
+
 /** accumulator stores procedure return values
     and also the address from which the value was obtained
     if the value is temporary (no place in variable), it's set
     to .adr = NULL */
-typedef struct {
+struct rt_VarTable_Acc_t{
     rt_Data_t val;
     rt_Data_t *adr;
-} rt_VarTable_Acc_t;
+};
 
 /* few globally defined variables */
 extern
@@ -58,7 +87,10 @@ void rt_VarTable_acc_setval(rt_Data_t val);
 void rt_VarTable_acc_setadr(rt_Data_t *adr);
 
 /** push a new function scope into the stack and store the procedure name and return address */
-void rt_VarTable_push_proc(const char *procname);
+void rt_VarTable_push_proc(const ast_Identifier_t *modulename, const ast_Identifier_t *procname, const char *filepath);
+
+/** get the procedure from the top of the stack */
+rt_VarTable_proc_t *rt_VarTable_proc_top(void);
 
 /** pop the procedure off the stack, return the return address and clear the scope from memory */
 rt_Data_t rt_VarTable_pop_proc(void);

--- a/include/runtime/VarTable.h
+++ b/include/runtime/VarTable.h
@@ -9,10 +9,10 @@
 #include "ast.h"
 #include "runtime/data/Data.h"
 
-#define _rt_TMPVAR_CNT (32)
-#define RT_ARGS_LIST_VARNAME "args"
-#define RT_DEFAULT_CALL_STACK_LIMIT (1000)
-#define RT_ACC_DATA (rt_VarTable_acc_get()->adr ? rt_VarTable_acc_get()->adr : &rt_VarTable_acc_get()->val)
+#define _RT_VTABLE_TMPVAR_CNT     (32)
+#define RT_VTABLE_ARGSVAR         "args"
+#define RT_VTABLE_CALLSTACK_LIMIT (1000)
+#define RT_VTABLE_ACC             (rt_VarTable_acc_get()->adr ? rt_VarTable_acc_get()->adr : &rt_VarTable_acc_get()->val)
 
 
 typedef rt_DataMap_t *rt_VarTable_Scope_t;

--- a/include/runtime/VarTable.h
+++ b/include/runtime/VarTable.h
@@ -90,7 +90,7 @@ void rt_VarTable_acc_setadr(rt_Data_t *adr);
 void rt_VarTable_push_proc(const ast_Identifier_t *modulename, const ast_Identifier_t *procname, const char *filepath);
 
 /** get the procedure from the top of the stack */
-rt_VarTable_proc_t *rt_VarTable_proc_top(void);
+rt_VarTable_proc_t *rt_VarTable_top_proc(void);
 
 /** pop the procedure off the stack, return the return address and clear the scope from memory */
 rt_Data_t rt_VarTable_pop_proc(void);

--- a/include/runtime/eval.h
+++ b/include/runtime/eval.h
@@ -10,12 +10,6 @@ typedef enum {
     rt_CTRL_CONTINUE,
 } rt_ControlStatus_t;
 
-extern const char *rt_currfile;
-extern int rt_currline;
-
-extern const ast_Identifier_t *rt_current_module;
-extern const ast_Identifier_t *rt_current_proc;
-
 rt_ControlStatus_t rt_eval_Statements(const ast_Statements_t *code);
 rt_ControlStatus_t rt_eval_Statements_newscope(const ast_Statements_t *code);
 rt_ControlStatus_t rt_eval_Statement(const ast_Statement_t *statement);

--- a/src/ast/util/ModuleAndProcTable.c.h
+++ b/src/ast/util/ModuleAndProcTable.c.h
@@ -132,7 +132,9 @@ const char *ast_util_ModuleAndProcTable_get_filename(const ast_Identifier_t *mod
 {
     const ast_util_ModuleAndProcTable_procedure_t proc = ast_util_ModuleAndProcTable_get(module_name, proc_name);
     if (!proc.procname)
-        rt_throw("ast_util_ModuleAndProcTable_get_filename: undefined procedure '%s:%s'", module_name->identifier_name, proc_name->identifier_name);
+        /* not printing current fn name as this error is most likely to occur when
+           main:main is not defined */
+        io_errndie("undefined procedure '%s:%s'", module_name->identifier_name, proc_name->identifier_name);
     return proc.src_filename;
 }
 

--- a/src/functions/module_dbg.c.h
+++ b/src/functions/module_dbg.c.h
@@ -11,7 +11,7 @@
 
 rt_Data_t fn_dbg_typename()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_dbg_typename: "
                    "received arguments list as type '%s'", rt_Data_typename(args));
@@ -22,7 +22,7 @@ rt_Data_t fn_dbg_typename()
 
 rt_Data_t fn_dbg_refcnt()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_dbg_refcnt: "
                    "received arguments list as type '%s'", rt_Data_typename(args));

--- a/src/functions/module_io.c.h
+++ b/src/functions/module_io.c.h
@@ -61,8 +61,8 @@ rt_Data_t fn_io_input()
         char *s = rt_Data_tostr(type_);
         rt_throw(
             "input: invalid type parameter: '%s'\n"
-            "  valid parameters are bul, chr, i64, f64 or str\n"
-            "  respective values are %d, %d, %d, %d or %d", s,
+            "valid parameters are bul, chr, i64, f64 or str\n"
+            "respective values are %d, %d, %d, %d or %d", s,
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
         free(s);
     }
@@ -70,8 +70,8 @@ rt_Data_t fn_io_input()
     if (!fn_io_input_type_isvalid(type_.data.i64))
         rt_throw(
             "input: invalid type parameter\n"
-            "  valid parameters are bul, chr, i64, f64 or str\n"
-            "  respective values are %d, %d, %d, %d or %d",
+            "valid parameters are bul, chr, i64, f64 or str\n"
+            "respective values are %d, %d, %d, %d or %d",
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
     rt_Data_print(prompt);
     switch (type) {
@@ -108,8 +108,8 @@ rt_Data_t fn_io_input()
         }
         default: rt_throw(
             "input: invalid type parameter\n"
-            "  valid parameters are bul, chr, i64, f64 or str\n"
-            "  respective values are %d, %d, %d, %d or %d",
+            "valid parameters are bul, chr, i64, f64 or str\n"
+            "respective values are %d, %d, %d, %d or %d",
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
             break;
     }

--- a/src/functions/module_io.c.h
+++ b/src/functions/module_io.c.h
@@ -27,7 +27,7 @@ int fn_io_input_str(char **val);
 
 rt_Data_t fn_io_print()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_io_print: "
                    "received arguments list as type '%s'", rt_Data_typename(args));
@@ -50,7 +50,7 @@ rt_Data_t fn_io_print()
 
 rt_Data_t fn_io_input()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_io_input: "
                    "received arguments list as type '%s'", rt_Data_typename(args));

--- a/src/functions/module_it.c.h
+++ b/src/functions/module_it.c.h
@@ -11,7 +11,7 @@
 
 rt_Data_t fn_it_len()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_it_len: "
                    "received arguments list as type '%s'", rt_Data_typename(args));

--- a/src/functions/nomodule.c.h
+++ b/src/functions/nomodule.c.h
@@ -12,7 +12,7 @@
 
 rt_Data_t fn_isnull()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_isnull: "
                    "received arguments list as type '%s'", rt_Data_typename(args));
@@ -22,7 +22,7 @@ rt_Data_t fn_isnull()
 
 rt_Data_t fn_tostr()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_tostr: "
                    "received arguments list as type '%s'", rt_Data_typename(args));
@@ -36,7 +36,7 @@ rt_Data_t fn_tostr()
 
 rt_Data_t fn_type()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("fn_type: "
                    "received arguments list as type '%s'", rt_Data_typename(args));

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -47,19 +47,6 @@ int rt_exec(int argc, char **argv)
     return rt_VarTable_pop_proc().data.i64;
 }
 
-const ast_Identifier_t *rt_modulename_get(void)
-{
-    if (!rt_current_module) rt_current_module = ast_util_ModuleAndProcTable_idfmain();
-    return rt_current_module;
-}
-
-const ast_Identifier_t *rt_procname_get(void)
-{
-    if (!rt_current_proc) rt_current_proc = ast_util_ModuleAndProcTable_idfmain();
-    return rt_current_proc;
-}
-
-
 #include "runtime/data/Data.c.h"
 #include "runtime/io.c.h"
 #include "runtime/eval/assignment.c.h"

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -11,20 +11,12 @@
 #include "runtime/io.h"
 #include "runtime/VarTable.h"
 
-
-const char *rt_currfile = NULL;
-int rt_currline = 0;
-
-const ast_Identifier_t *rt_current_module = NULL;
-const ast_Identifier_t *rt_current_proc = NULL;
-
-
 int rt_exec(int argc, char **argv)
 {
     const ast_Identifier_t *module = ast_util_ModuleAndProcTable_idfmain();
     const ast_Identifier_t *proc = ast_util_ModuleAndProcTable_idfmain();
     const ast_Statements_t *code = ast_util_ModuleAndProcTable_get_code(module, proc);
-    rt_currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
+    const char *currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
 
     /* generate args list w/ cli args passed from main
        here we do skip the path to the interpreter so args[0]
@@ -35,8 +27,8 @@ int rt_exec(int argc, char **argv)
         rt_DataList_append(args.data.lst, arg);
     }
 
-    rt_VarTable_push_proc(proc->identifier_name);
-    rt_VarTable_create(RT_ARGS_LIST_VARNAME, args, true);
+    rt_VarTable_push_proc(module, proc, currfile);
+    rt_VarTable_create(RT_VTABLE_ARGSVAR, args, true);
 
     rt_ControlStatus_t ctrl = rt_eval_Statements(code);
     if (ctrl == rt_CTRL_BREAK)

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "ast.h"
 #include "ast/api.h"
 #include "ast/nodes/enums.h"
 #include "io.h"
@@ -17,24 +18,6 @@
 #include "runtime/io.h"
 #include "runtime/VarTable.h"
 #include "tlib/khash/khash.h"
-
-typedef rt_DataMap_t *rt_VarTable_Scope_t;
-
-
-/** the scopes stack of a procedure */
-typedef struct {
-    rt_VarTable_Scope_t *scopes;
-    int64_t curr_scope_ptr;
-    size_t capacity;
-} rt_VarTable_proc_t;
-
-
-/** the VarTable is basically the call stack */
-typedef struct {
-    rt_VarTable_proc_t *procs;
-    int64_t curr_proc_ptr;
-    size_t capacity;
-} rt_VarTable_t;
 
 
 /** gloablly allocated stack pointer */
@@ -167,8 +150,11 @@ void rt_VarTable_acc_setadr(rt_Data_t *adr)
 }
 
 
-void rt_VarTable_push_proc(const char *procname)
-{
+void rt_VarTable_push_proc(
+    const ast_Identifier_t *modulename,
+    const ast_Identifier_t *procname,
+    const char *filepath
+) {
     /* check if the stack is already initialized */
     if (rt_vtable == NULL) {
         rt_vtable = (rt_VarTable_t*) malloc(sizeof(rt_VarTable_t));
@@ -191,6 +177,10 @@ void rt_VarTable_push_proc(const char *procname)
     rt_vtable->procs[rt_vtable->curr_proc_ptr].scopes = NULL;
     rt_vtable->procs[rt_vtable->curr_proc_ptr].curr_scope_ptr = -1;
     rt_vtable->procs[rt_vtable->curr_proc_ptr].capacity = 0;
+    rt_vtable->procs[rt_vtable->curr_proc_ptr].modulename = modulename;
+    rt_vtable->procs[rt_vtable->curr_proc_ptr].procname = procname;
+    rt_vtable->procs[rt_vtable->curr_proc_ptr].filepath = filepath;
+    rt_vtable->procs[rt_vtable->curr_proc_ptr].current_line = -1;
     /* push a new local scope */
     rt_VarTable_push_scope();
 }

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -185,6 +185,13 @@ void rt_VarTable_push_proc(
     rt_VarTable_push_scope();
 }
 
+rt_VarTable_proc_t *rt_VarTable_proc_top(void)
+{
+    if (rt_vtable == NULL || rt_vtable->curr_proc_ptr == -1)
+        return NULL;
+    return &(rt_vtable->procs[rt_vtable->curr_proc_ptr]);
+}
+
 rt_Data_t rt_VarTable_pop_proc(void)
 {
     if (rt_vtable == NULL || rt_vtable->curr_proc_ptr == -1)

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -63,7 +63,7 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
 void rt_VarTable_create(const char *varname, rt_Data_t value, bool is_const)
 {
     if ( (!isalpha(varname[0]) && varname[0] != '_'
-        && strcmp(varname, RT_ARGS_LIST_VARNAME)) || isdigit(varname[0]) )
+        && strcmp(varname, RT_VTABLE_ARGSVAR)) || isdigit(varname[0]) )
             io_errndie("rt_VarTable_create: invalid new variable name '%s'", varname);
     else {
         rt_Data_t *globvar = rt_VarTable_get_globvar(varname);
@@ -100,7 +100,7 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src)
 rt_Data_t *rt_VarTable_getref_errnull(const char *varname)
 {
     if ( (!isalpha(varname[0]) && varname[0] != '_'
-        && strcmp(varname, RT_ARGS_LIST_VARNAME)) || isdigit(varname[0]) )
+        && strcmp(varname, RT_VTABLE_ARGSVAR)) || isdigit(varname[0]) )
             io_errndie("rt_VarTable_getref: invalid variable name '%s'", varname);
     else {
         rt_Data_t *globvar = rt_VarTable_get_globvar(varname);
@@ -164,7 +164,7 @@ void rt_VarTable_push_proc(
         rt_vtable->capacity = 0;
     }
     /* check if call stack has exceeded a default limit */
-    if (rt_vtable->curr_proc_ptr >= RT_DEFAULT_CALL_STACK_LIMIT)
+    if (rt_vtable->curr_proc_ptr >= RT_VTABLE_CALLSTACK_LIMIT)
         rt_throw("call stack limit exceeded");
     /* increase the capacity if needed */
     if (rt_vtable->curr_proc_ptr >= rt_vtable->capacity -1) {
@@ -195,7 +195,7 @@ rt_Data_t rt_VarTable_pop_proc(void)
        in the event that the accumulator data is not a val but an adr
        i.e. a ref to some value in the table.
        thus, we use this to convert the adr into a val */
-    rt_VarTable_acc_setval(*RT_ACC_DATA);
+    rt_VarTable_acc_setval(*RT_VTABLE_ACC);
     /* pop all scopes in that proc */
     while (current_proc->curr_scope_ptr >= 0) {
         rt_VarTable_pop_scope();
@@ -206,7 +206,7 @@ rt_Data_t rt_VarTable_pop_proc(void)
         rt_vtable->procs = NULL;
         rt_vtable->capacity = 0;
     }
-    return *RT_ACC_DATA;
+    return *RT_VTABLE_ACC;
 }
 
 
@@ -235,7 +235,7 @@ rt_Data_t rt_VarTable_pop_scope(void)
        in the event that the accumulator data is not a val but an adr
        i.e. a ref to some value in the table.
        thus, we use this to convert the adr into a val */
-    rt_VarTable_acc_setval(*RT_ACC_DATA);
+    rt_VarTable_acc_setval(*RT_VTABLE_ACC);
     /* get the current scope */
     rt_VarTable_Scope_t *current_scope = &(current_proc->scopes[current_proc->curr_scope_ptr]);
     /* destroy map of values */
@@ -247,7 +247,7 @@ rt_Data_t rt_VarTable_pop_scope(void)
         current_proc->scopes = NULL;
         current_proc->capacity = 0;
     }
-    return *RT_ACC_DATA;
+    return *RT_VTABLE_ACC;
 }
 
 

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -185,7 +185,7 @@ void rt_VarTable_push_proc(
     rt_VarTable_push_scope();
 }
 
-rt_VarTable_proc_t *rt_VarTable_proc_top(void)
+rt_VarTable_proc_t *rt_VarTable_top_proc(void)
 {
     if (rt_vtable == NULL || rt_vtable->curr_proc_ptr == -1)
         return NULL;

--- a/src/runtime/eval/assignment.c.h
+++ b/src/runtime/eval/assignment.c.h
@@ -16,13 +16,13 @@ void rt_eval_Assignment(const ast_Assignment_t *assignment)
         case ASSIGNMENT_TYPE_CREATE: {
             const char *idf = assignment->lhs->identifier_name;
             rt_eval_Expression(assignment->rhs);
-            rt_VarTable_create(idf, *RT_ACC_DATA, false);
+            rt_VarTable_create(idf, *RT_VTABLE_ACC, false);
             break;
         }
         case ASSIGNMENT_TYPE_MKCONST: {
             const char *idf = assignment->lhs->identifier_name;
             rt_eval_Expression(assignment->rhs);
-            rt_VarTable_create(idf, *RT_ACC_DATA, true);
+            rt_VarTable_create(idf, *RT_VTABLE_ACC, true);
             break;
         }
     }

--- a/src/runtime/eval/associativelist.c.h
+++ b/src/runtime/eval/associativelist.c.h
@@ -18,12 +18,12 @@ void rt_eval_AssociativeList(const ast_AssociativeList_t *assoc_list)
     rt_DataMap_t *new_map = rt_DataMap_init();
     while (ptr) {
         rt_eval_Literal(ptr->key);
-        char *key_cstr = rt_Data_tostr(*RT_ACC_DATA);
+        char *key_cstr = rt_Data_tostr(*RT_VTABLE_ACC);
         /* note that the rt_Data_t string returned above is not
            manually cleaned coz it's reference counted l, and is
            freed when accumulator value is changed below */
         rt_eval_Expression(ptr->value);
-        rt_DataMap_insert(new_map, key_cstr, *RT_ACC_DATA);
+        rt_DataMap_insert(new_map, key_cstr, *RT_VTABLE_ACC);
         ptr = ptr->assoc_list;
         free(key_cstr);
     }

--- a/src/runtime/eval/commaseplist.c.h
+++ b/src/runtime/eval/commaseplist.c.h
@@ -17,7 +17,7 @@ void rt_eval_CommaSepList(const ast_CommaSepList_t *comma_list)
     rt_DataList_t *new_list = rt_DataList_init();
     while (ptr) {
         rt_eval_Expression(ptr->expression);
-        rt_DataList_append(new_list, *RT_ACC_DATA);
+        rt_DataList_append(new_list, *RT_VTABLE_ACC);
         ptr = ptr->comma_list;
     }
     rt_VarTable_acc_setval(

--- a/src/runtime/eval/expression.c.h
+++ b/src/runtime/eval/expression.c.h
@@ -30,7 +30,7 @@ rt_Data_t *rt_eval_Expression_operand(
     if (is_lhs && op == TOKOP_FNCALL && oprnd_type == EXPR_TYPE_IDENTIFIER) {
         rt_VarTable_acc_setval((rt_Data_t) {
             .data.proc = {
-                .modulename = rt_VarTable_proc_top()->modulename,
+                .modulename = rt_VarTable_top_proc()->modulename,
                 .procname = oprnd.variable,
             },
             .type = rt_DATA_TYPE_PROC

--- a/src/runtime/eval/expression.c.h
+++ b/src/runtime/eval/expression.c.h
@@ -30,7 +30,7 @@ rt_Data_t *rt_eval_Expression_operand(
     if (is_lhs && op == TOKOP_FNCALL && oprnd_type == EXPR_TYPE_IDENTIFIER) {
         rt_VarTable_acc_setval((rt_Data_t) {
             .data.proc = {
-                .modulename = rt_modulename_get(),
+                .modulename = rt_VarTable_proc_top()->modulename,
                 .procname = oprnd.variable,
             },
             .type = rt_DATA_TYPE_PROC
@@ -59,7 +59,7 @@ rt_Data_t *rt_eval_Expression_operand(
 rt_eval_Expression_operand_return:
     /* copy accumulator value into temporary memory as accumulator gets
        modified when evaluating other operands */
-    *oprnd_data = *RT_ACC_DATA;
+    *oprnd_data = *RT_VTABLE_ACC;
     return rt_VarTable_acc_get()->adr ? rt_VarTable_acc_get()->adr : oprnd_data;
 }
 

--- a/src/runtime/eval/forblock.c.h
+++ b/src/runtime/eval/forblock.c.h
@@ -21,17 +21,17 @@ rt_ControlStatus_t rt_eval_ForBlock(const ast_ForBlock_t *for_block)
         case FORBLOCK_TYPE_RANGE: {
             /* calculate start, end and by */
             rt_eval_Expression(for_block->it.range.start);
-            rt_Data_t start = *RT_ACC_DATA;
+            rt_Data_t start = *RT_VTABLE_ACC;
             if (start.type != rt_DATA_TYPE_I64)
                 rt_throw("for loop range start should be an i64, not '%s'", rt_Data_typename(start));
             rt_eval_Expression(for_block->it.range.end);
-            rt_Data_t end = *RT_ACC_DATA;
+            rt_Data_t end = *RT_VTABLE_ACC;
             if (end.type != rt_DATA_TYPE_I64)
                 rt_throw("for loop range end should be an i64, not '%s'", rt_Data_typename(start));
             rt_Data_t by = rt_Data_null();
             if (for_block->it.range.by) {
                 rt_eval_Expression(for_block->it.range.by);
-                by = *RT_ACC_DATA;
+                by = *RT_VTABLE_ACC;
                 if (by.type != rt_DATA_TYPE_I64)
                     rt_throw("for loop by value should be an i64, not '%s'", rt_Data_typename(start));
             }
@@ -61,7 +61,7 @@ rt_ControlStatus_t rt_eval_ForBlock(const ast_ForBlock_t *for_block)
         case FORBLOCK_TYPE_LIST: {
             /* convert expression to a data list */
             rt_eval_Expression(for_block->it.iterable);
-            rt_Data_t iterable = *RT_ACC_DATA;
+            rt_Data_t iterable = *RT_VTABLE_ACC;
             rt_Data_copy(&iterable);
             int64_t length = 0;
             switch (iterable.type) {

--- a/src/runtime/eval/ifblock.c.h
+++ b/src/runtime/eval/ifblock.c.h
@@ -13,7 +13,7 @@ rt_ControlStatus_t rt_eval_IfBlock(const ast_IfBlock_t *if_block)
 {
     if (!if_block) return rt_CTRL_PASS;
     rt_eval_Expression(if_block->condition);
-    bool cond = rt_Data_tobool(*RT_ACC_DATA);
+    bool cond = rt_Data_tobool(*RT_VTABLE_ACC);
     if (cond) return rt_eval_Statements_newscope(if_block->if_st);
     else return rt_eval_ElseBlock(if_block->else_block);
 }
@@ -27,7 +27,7 @@ rt_ControlStatus_t rt_eval_ElseBlock(const ast_ElseBlock_t *else_block)
     }
     /* takes care of [ else if condition then nwp statements ] */
     rt_eval_Expression(else_block->condition);
-    bool cond = rt_Data_tobool(*RT_ACC_DATA);
+    bool cond = rt_Data_tobool(*RT_VTABLE_ACC);
     if (cond) return rt_eval_Statements_newscope(else_block->else_if_st);
     else return rt_eval_ElseBlock(else_block->else_block);
 }

--- a/src/runtime/eval/statement.c.h
+++ b/src/runtime/eval/statement.c.h
@@ -9,7 +9,7 @@
 rt_ControlStatus_t rt_eval_Statement(const ast_Statement_t *statement)
 {
     if (!statement) return rt_CTRL_PASS;
-    rt_VarTable_proc_top()->current_line = statement->line_no;
+    rt_VarTable_top_proc()->current_line = statement->line_no;
     switch (statement->type) {
         case STATEMENT_TYPE_EMPTY:
             return rt_CTRL_PASS;

--- a/src/runtime/eval/statement.c.h
+++ b/src/runtime/eval/statement.c.h
@@ -4,11 +4,12 @@
 #include "ast.h"
 #include "ast/api.h"
 #include "runtime/eval.h"
+#include "runtime/VarTable.h"
 
 rt_ControlStatus_t rt_eval_Statement(const ast_Statement_t *statement)
 {
     if (!statement) return rt_CTRL_PASS;
-    rt_currline = statement->line_no;
+    rt_VarTable_proc_top()->current_line = statement->line_no;
     switch (statement->type) {
         case STATEMENT_TYPE_EMPTY:
             return rt_CTRL_PASS;

--- a/src/runtime/eval/statements.c.h
+++ b/src/runtime/eval/statements.c.h
@@ -20,8 +20,8 @@ rt_ControlStatus_t rt_eval_Statements(const ast_Statements_t *code)
            to rt_Data_i64(0) */
         rt_Data_t exit_code = rt_Data_null();
         if (   !ptr->statements
-            && !strcmp(rt_modulename_get()->identifier_name, "main")
-            && !strcmp(rt_procname_get()->identifier_name, "main")
+            && !strcmp(rt_VarTable_proc_top()->modulename->identifier_name, "main")
+            && !strcmp(rt_VarTable_proc_top()->procname->identifier_name, "main")
             && ptr->statement && ptr->statement->type != STATEMENT_TYPE_RETURN) {
             exit_code = rt_Data_i64(0);
         }

--- a/src/runtime/eval/statements.c.h
+++ b/src/runtime/eval/statements.c.h
@@ -20,8 +20,8 @@ rt_ControlStatus_t rt_eval_Statements(const ast_Statements_t *code)
            to rt_Data_i64(0) */
         rt_Data_t exit_code = rt_Data_null();
         if (   !ptr->statements
-            && !strcmp(rt_VarTable_proc_top()->modulename->identifier_name, "main")
-            && !strcmp(rt_VarTable_proc_top()->procname->identifier_name, "main")
+            && !strcmp(rt_VarTable_top_proc()->modulename->identifier_name, "main")
+            && !strcmp(rt_VarTable_top_proc()->procname->identifier_name, "main")
             && ptr->statement && ptr->statement->type != STATEMENT_TYPE_RETURN) {
             exit_code = rt_Data_i64(0);
         }

--- a/src/runtime/eval/whileblock.c.h
+++ b/src/runtime/eval/whileblock.c.h
@@ -13,7 +13,7 @@ rt_ControlStatus_t rt_eval_WhileBlock(const ast_WhileBlock_t *while_block)
 {
     if (!while_block) return rt_CTRL_PASS;
     rt_eval_Expression(while_block->condition);
-    bool cond = rt_Data_tobool(*RT_ACC_DATA);
+    bool cond = rt_Data_tobool(*RT_VTABLE_ACC);
     while (cond) {
         rt_ControlStatus_t ctrl = rt_eval_Statements_newscope(while_block->statements);
         if (ctrl == rt_CTRL_PASS)

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -8,6 +8,7 @@
 #include "errcodes.h"
 #include "runtime.h"
 #include "runtime/io.h"
+#include "runtime/VarTable.h"
 
 #define RT_THROW_PRINT_FN      "%s:%s: "
 #define RT_THROW_DONT_PRINT_FN ""
@@ -25,6 +26,21 @@ void rt_throw(const char *fmt, ...)
     va_end(args);
     fflush(stderr);
     fprintf(stderr, "\n");
+
+#if 0
+    /* print stack trace */
+    while (rt_VarTable_proc_top()) {
+        fprintf(stderr, "    at " RT_THROW_PRINT_FN "(%s:%d)\n",
+            rt_VarTable_proc_top()->modulename->identifier_name,
+            rt_VarTable_proc_top()->procname->identifier_name,
+            rt_VarTable_proc_top()->filepath,
+            rt_VarTable_proc_top()->line
+        );
+        rt_VarTable_pop_proc();
+    }
+    fflush(stderr);
+#endif
+
 #ifdef DEBUG
     abort();
 #else

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "ast/api.h"
 #include "errcodes.h"
 #include "runtime.h"
 #include "runtime/io.h"
@@ -27,19 +28,17 @@ void rt_throw(const char *fmt, ...)
     fflush(stderr);
     fprintf(stderr, "\n");
 
-#if 0
     /* print stack trace */
     while (rt_VarTable_proc_top()) {
         fprintf(stderr, "    at " RT_THROW_PRINT_FN "(%s:%d)\n",
             rt_VarTable_proc_top()->modulename->identifier_name,
             rt_VarTable_proc_top()->procname->identifier_name,
             rt_VarTable_proc_top()->filepath,
-            rt_VarTable_proc_top()->line
+            rt_VarTable_proc_top()->current_line
         );
         rt_VarTable_pop_proc();
     }
     fflush(stderr);
-#endif
 
 #ifdef DEBUG
     abort();

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -11,8 +11,9 @@
 #include "runtime/io.h"
 #include "runtime/VarTable.h"
 
-#define RT_THROW_PRINT_FN      "%s:%s: "
-#define RT_THROW_DONT_PRINT_FN ""
+#define RT_IO_TRACE_LIMIT         (100)
+#define RT_IO_THROW_PRINT_FN      "%s:%s"
+#define RT_IO_THROW_DONT_PRINT_FN ""
 
 void rt_throw(const char *fmt, ...)
 {

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -17,10 +17,11 @@
 
 void rt_throw(const char *fmt, ...)
 {
-    fprintf(stderr, "shsc: " RT_THROW_DONT_PRINT_FN "%s:%d: ",
-        /* rt_modulename_get()->identifier_name, */
-            /* rt_procname_get()->identifier_name, */
-                rt_currfile, rt_currline);
+    fprintf(stderr, "shsc: " RT_IO_THROW_DONT_PRINT_FN "%s:%d: ",
+        /* rt_VarTable_proc_top()->modulename->identifier_name, */
+        /* rt_VarTable_proc_top()->procname->identifier_name, */
+        rt_VarTable_proc_top()->filepath,
+        rt_VarTable_proc_top()->current_line);
     fflush(stderr);
     va_list args;
     va_start(args, fmt);
@@ -30,14 +31,18 @@ void rt_throw(const char *fmt, ...)
     fprintf(stderr, "\n");
 
     /* print stack trace */
-    while (rt_VarTable_proc_top()) {
-        fprintf(stderr, "    at " RT_THROW_PRINT_FN "(%s:%d)\n",
+    int trace_lim_i = 0;
+    while (rt_VarTable_proc_top() && trace_lim_i++ < RT_IO_TRACE_LIMIT) {
+        fprintf(stderr, "    at " RT_IO_THROW_PRINT_FN " (%s:%d)\n",
             rt_VarTable_proc_top()->modulename->identifier_name,
             rt_VarTable_proc_top()->procname->identifier_name,
             rt_VarTable_proc_top()->filepath,
             rt_VarTable_proc_top()->current_line
         );
         rt_VarTable_pop_proc();
+    }
+    if (trace_lim_i >= RT_IO_TRACE_LIMIT) {
+        fprintf(stderr, "    ...\n");
     }
     fflush(stderr);
 

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -18,10 +18,10 @@
 void rt_throw(const char *fmt, ...)
 {
     fprintf(stderr, "shsc: " RT_IO_THROW_DONT_PRINT_FN "%s:%d: ",
-        /* rt_VarTable_proc_top()->modulename->identifier_name, */
-        /* rt_VarTable_proc_top()->procname->identifier_name, */
-        rt_VarTable_proc_top()->filepath,
-        rt_VarTable_proc_top()->current_line);
+        /* rt_VarTable_top_proc()->modulename->identifier_name, */
+        /* rt_VarTable_top_proc()->procname->identifier_name, */
+        rt_VarTable_top_proc()->filepath,
+        rt_VarTable_top_proc()->current_line);
     fflush(stderr);
     va_list args;
     va_start(args, fmt);
@@ -32,12 +32,12 @@ void rt_throw(const char *fmt, ...)
 
     /* print stack trace */
     int trace_lim_i = 0;
-    while (rt_VarTable_proc_top() && trace_lim_i++ < RT_IO_TRACE_LIMIT) {
+    while (rt_VarTable_top_proc() && trace_lim_i++ < RT_IO_TRACE_LIMIT) {
         fprintf(stderr, "    at " RT_IO_THROW_PRINT_FN " (%s:%d)\n",
-            rt_VarTable_proc_top()->modulename->identifier_name,
-            rt_VarTable_proc_top()->procname->identifier_name,
-            rt_VarTable_proc_top()->filepath,
-            rt_VarTable_proc_top()->current_line
+            rt_VarTable_top_proc()->modulename->identifier_name,
+            rt_VarTable_top_proc()->procname->identifier_name,
+            rt_VarTable_top_proc()->filepath,
+            rt_VarTable_top_proc()->current_line
         );
         rt_VarTable_pop_proc();
     }

--- a/src/runtime/operators/tokop_fnargs_indexing.c.h
+++ b/src/runtime/operators/tokop_fnargs_indexing.c.h
@@ -12,7 +12,7 @@ void rt_op_fnargs_indexing(const rt_Data_t *lhs, const rt_Data_t *rhs)
 {
     if (!rhs || rhs->type != rt_DATA_TYPE_I64)
         rt_throw("argument index should evaluate to an `i64`");
-    rt_Data_t args = *rt_VarTable_getref(RT_ARGS_LIST_VARNAME);
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
     if (args.type != rt_DATA_TYPE_LST)
         io_errndie("rt_eval_Expression: TOKOP_FNARGS_INDEXING: "
                    "received arguments list as type '%s'", rt_Data_typename(args));

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -46,7 +46,7 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
     if (code) {
         currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
     } else if (fn != fn_UNDEFINED) {
-        currfile = rt_VarTable_proc_top()->filepath;
+        currfile = rt_VarTable_top_proc()->filepath;
     }
     rt_VarTable_push_proc(module, proc, currfile);
     /* store fn args into agrs location */

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -56,7 +56,7 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
     }
     rt_VarTable_push_proc(proc, module, rt_currfile);
     /* store fn args into agrs location */
-    rt_VarTable_create(RT_ARGS_LIST_VARNAME, args, true);
+    rt_VarTable_create(RT_VTABLE_ARGSVAR, args, true);
     if (code) {
         /* call user defined function */
         rt_eval_Statements(code);

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -46,7 +46,7 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
     if (code) {
         currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
     } else if (fn != fn_UNDEFINED) {
-        currfile = "built-in";
+        currfile = module->identifier_name;
     } else {
         rt_throw("undefined procedure '%s:%s'",
             module->identifier_name, proc->identifier_name);

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -5,6 +5,7 @@
 #include "ast/api.h"
 #include "functions.h"
 #include "io.h"
+#include "runtime.h"
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/eval.h"
@@ -53,7 +54,7 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
         rt_current_module = module;
         rt_current_proc = proc;
     }
-    rt_VarTable_push_proc(proc->identifier_name);
+    rt_VarTable_push_proc(proc, module, rt_currfile);
     /* store fn args into agrs location */
     rt_VarTable_create(RT_ARGS_LIST_VARNAME, args, true);
     if (code) {

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -46,7 +46,10 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
     if (code) {
         currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
     } else if (fn != fn_UNDEFINED) {
-        currfile = rt_VarTable_top_proc()->filepath;
+        currfile = "built-in";
+    } else {
+        rt_throw("undefined procedure '%s:%s'",
+            module->identifier_name, proc->identifier_name);
     }
     rt_VarTable_push_proc(module, proc, currfile);
     /* store fn args into agrs location */
@@ -55,10 +58,7 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
         /* call user defined function */
         rt_eval_Statements(code);
     } else {
-        /* attempt to call in-built function */
-        if (fn == fn_UNDEFINED)
-            rt_throw("undefined procedure '%s:%s'",
-                module->identifier_name, proc->identifier_name);
+        /* call in-built function */
         rt_VarTable_acc_setval(fn_FunctionsList_call(fn));
     }
     rt_VarTable_pop_proc();

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -40,21 +40,15 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
     /* get a descriptor to in-built function */
     const fn_FunctionDescriptor_t fn = fn_FunctionsList_getfn(
         module->identifier_name, proc->identifier_name);
-    /* backup metadata on current module and function */
-    const char *currfile_bkp = rt_currfile;
-    const ast_Identifier_t *currmodule_bkp = rt_current_module;
-    const ast_Identifier_t *currproc_bkp = rt_current_proc;
+
+    const char *currfile = NULL;
     /* update metadata to new module and function */
     if (code) {
-        rt_currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
-        rt_current_module = module;
-        rt_current_proc = proc;
+        currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
     } else if (fn != fn_UNDEFINED) {
-        /* rt_currfile = rt_currfile; */
-        rt_current_module = module;
-        rt_current_proc = proc;
+        currfile = rt_VarTable_proc_top()->filepath;
     }
-    rt_VarTable_push_proc(proc, module, rt_currfile);
+    rt_VarTable_push_proc(module, proc, currfile);
     /* store fn args into agrs location */
     rt_VarTable_create(RT_VTABLE_ARGSVAR, args, true);
     if (code) {
@@ -68,10 +62,6 @@ void rt_op_fncall_handler(const ast_Identifier_t *module, const ast_Identifier_t
         rt_VarTable_acc_setval(fn_FunctionsList_call(fn));
     }
     rt_VarTable_pop_proc();
-    /* restore metadata to previous module and function */
-    rt_currfile = currfile_bkp;
-    rt_current_module = currmodule_bkp;
-    rt_current_proc = currproc_bkp;
 }
 
 #else


### PR DESCRIPTION
- added stack strace in rt_throw
- added init support for stack trace
- updated fn call op
- renamed rt VarTable macros
- renamed rt io macros
- added impl of rt_VarTable_proc_top
- using impl of rt_VarTable_proc_top
- ren top_proc to proc_top
- na
- ModuleAndProcTable: improved err msg
- print error before pushing new frame: retains info about a valid frame in stack top
- display module instead of built-in for err thrown by built-in procs
- module based namespacing in action
