### PR TITLE
v0.7.1: cyclic refs cannot be created and such objects get set to null

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#define VERSION "0.7 Alpha"
+#define VERSION "0.7.1 Alpha"
 #define AUTHORS "Aviruk Basak"
 #define GLOBAL_BYTES_BUFFER_LEN (128)
 

--- a/include/runtime/data/Data.h
+++ b/include/runtime/data/Data.h
@@ -64,6 +64,7 @@ rt_Data_t rt_Data_proc(
 rt_Data_t rt_Data_any(void *ptr);
 rt_Data_t rt_Data_null(void);
 void rt_Data_copy(rt_Data_t *var);
+void rt_Data_destroy_circular(rt_Data_t *var, bool flag);
 void rt_Data_destroy(rt_Data_t *var);
 
 bool rt_Data_isnull(const rt_Data_t var);

--- a/include/runtime/data/DataList.h
+++ b/include/runtime/data/DataList.h
@@ -1,6 +1,7 @@
 #ifndef RT_DATA_LIST_H
 #define RT_DATA_LIST_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "runtime/data/Data.h"
@@ -15,6 +16,7 @@ struct rt_DataList_t {
 rt_DataList_t *rt_DataList_init();
 int64_t rt_DataList_length(const rt_DataList_t *lst);
 void rt_DataList_copy(rt_DataList_t *lst);
+void rt_DataList_destroy_circular(rt_DataList_t **ptr, bool flag);
 void rt_DataList_destroy(rt_DataList_t **ptr);
 void rt_DataList_append(rt_DataList_t *lst, rt_Data_t var);
 rt_Data_t *rt_DataList_getref_errnull(const rt_DataList_t *lst, int64_t idx);

--- a/include/runtime/data/DataMap.h
+++ b/include/runtime/data/DataMap.h
@@ -1,6 +1,7 @@
 #ifndef RT_DATA_MAP_H
 #define RT_DATA_MAP_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "tlib/khash/khash.h"
@@ -24,6 +25,7 @@ typedef khiter_t rt_DataMap_iter_t;
 rt_DataMap_t *rt_DataMap_init();
 int64_t rt_DataMap_length(const rt_DataMap_t *mp);
 void rt_DataMap_copy(rt_DataMap_t *mp);
+void rt_DataMap_destroy_circular(rt_DataMap_t **ptr, bool flag);
 void rt_DataMap_destroy(rt_DataMap_t **ptr);
 void rt_DataMap_insert(rt_DataMap_t *mp, const char *key, rt_Data_t value);
 const char *rt_DataMap_getkey_copy(const rt_DataMap_t *mp, const char *key);

--- a/include/runtime/data/DataStr.h
+++ b/include/runtime/data/DataStr.h
@@ -1,6 +1,7 @@
 #ifndef RT_DATA_STRING_H
 #define RT_DATA_STRING_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,6 +14,7 @@ struct rt_DataStr_t {
 rt_DataStr_t *rt_DataStr_init(const char *s);
 int64_t rt_DataStr_length(const rt_DataStr_t *str);
 void rt_DataStr_copy(rt_DataStr_t *str);
+void rt_DataStr_destroy_circular(rt_DataStr_t **ptr, bool flag);
 void rt_DataStr_destroy(rt_DataStr_t **ptr);
 void rt_DataStr_append(rt_DataStr_t *str, char ch);
 char *rt_DataStr_getref_errnull(const rt_DataStr_t *str, int64_t idx);

--- a/include/runtime/data/GarbageColl.h
+++ b/include/runtime/data/GarbageColl.h
@@ -1,0 +1,12 @@
+#ifndef RT_GARBAGE_COLL_H
+#define RT_GARBAGE_COLL_H
+
+#include "runtime/data/Data.h"
+
+/** check if rc of passed object is contributed to only by cyclic references */
+bool rt_data_GC_has_only_cyclic_refcnt(const rt_Data_t var);
+
+/** count total number of cyclic references back to the passed data object */
+int64_t rt_data_GC_cyclic_count(const rt_Data_t var);
+
+#endif

--- a/include/runtime/data/GarbageColl.h
+++ b/include/runtime/data/GarbageColl.h
@@ -6,6 +6,9 @@
 /** check if rc of passed object is contributed to only by cyclic references */
 bool rt_data_GC_has_only_cyclic_refcnt(const rt_Data_t var);
 
+/** break cyclic refs */
+void rt_data_GC_break_cycle(const rt_Data_t var, const rt_Data_t tg);
+
 /** count total number of cyclic references back to the passed data object */
 int64_t rt_data_GC_cyclic_count(const rt_Data_t var);
 

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -27,6 +27,7 @@ typedef enum {
     rt_fn_DBG_REFCNT,    /* dbg:refcnt */
     rt_fn_DBG_FILENAME,  /* dbg:filename */
     rt_fn_DBG_LINENO,    /* dbg:lineno */
+    rt_fn_DBG_ID,        /* dbg:id */
 
     rt_fn_IO_PRINT,      /* io:print */
     rt_fn_IO_INPUT,      /* io:input */

--- a/include/runtime/functions/module_dbg.h
+++ b/include/runtime/functions/module_dbg.h
@@ -5,5 +5,6 @@
 
 rt_Data_t rt_fn_dbg_typename();
 rt_Data_t rt_fn_dbg_refcnt();
+rt_Data_t rt_fn_dbg_id();
 
 #endif

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -246,7 +246,7 @@ rt_Data_t rt_VarTable_pop_scope(void)
     /* get the current scope */
     rt_VarTable_Scope_t *current_scope = &(current_proc->scopes[current_proc->curr_scope_ptr]);
     /* destroy map of values */
-    rt_DataMap_destroy(current_scope);
+    rt_DataMap_destroy_circular(current_scope, true);
     --current_proc->curr_scope_ptr;
     /* if there are no scopes left in the current procedure free the stack */
     if (current_proc->curr_scope_ptr == -1) {

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -15,6 +15,7 @@
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataMap.h"
+#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 #include "runtime/VarTable.h"
 #include "tlib/khash/khash.h"
@@ -245,7 +246,49 @@ rt_Data_t rt_VarTable_pop_scope(void)
     rt_VarTable_acc_setval(*RT_VTABLE_ACC);
     /* get the current scope */
     rt_VarTable_Scope_t *current_scope = &(current_proc->scopes[current_proc->curr_scope_ptr]);
-    /* destroy map of values */
+
+    /* destroy map of values
+       uses the gc module to find and break circular refs */
+    for (
+        rt_DataMap_iter_t it = rt_DataMap_begin(*current_scope);
+        it != rt_DataMap_end(*current_scope);
+        ++it
+    ) {
+        if (!rt_DataMap_exists(*current_scope, it)) continue;
+        const rt_DataMapEntry_t *entry = rt_DataMap_get(*current_scope, it);
+        rt_Data_t *ref = (rt_Data_t*) &entry->value;
+        if (!ref) continue;
+        rt_Data_t data = *ref;
+        if (data.type == rt_DATA_TYPE_STR || data.type == rt_DATA_TYPE_INTERP_STR)
+            data = rt_Data_list(data.data.str->var);
+        if (data.type == rt_DATA_TYPE_LST) {
+            if (data.data.lst->rc > 0) {
+                /* if rc > 0, check if the data has only cyclic references
+                   if so, set rc to 0 to free the data */
+                if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_list(data.data.lst))) {
+                    rt_data_GC_break_cycle(
+                        rt_Data_list(data.data.lst),
+                        rt_Data_list(data.data.lst)
+                    );
+                    data.data.lst->rc = 0;
+                }
+            }
+        }
+        else if (data.type == rt_DATA_TYPE_MAP) {
+            if (data.data.mp->rc > 0) {
+                /* if rc > 0, check if the data has only cyclic references
+                   if so, set rc to 0 to free the data */
+                if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_map(data.data.mp))) {
+                    rt_data_GC_break_cycle(
+                        rt_Data_map(data.data.mp),
+                        rt_Data_map(data.data.mp)
+                    );
+                    data.data.mp->rc = 0;
+                }
+            }
+        }
+    }
+
     rt_DataMap_destroy(current_scope);
     --current_proc->curr_scope_ptr;
     /* if there are no scopes left in the current procedure free the stack */

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -312,8 +312,8 @@ char *rt_Data_tostr(const rt_Data_t var)
             char *str = (char*) malloc((sz +1) * sizeof(char));
             if (!str) io_errndie("rt_Data_tostr:" ERR_MSG_MALLOCFAIL);
             sprintf(str, "%s:%s",
-                var.data.proc.procname->identifier_name,
-                var.data.proc.modulename->identifier_name
+                var.data.proc.modulename->identifier_name,
+                var.data.proc.procname->identifier_name
             );
             return str;
         }

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -53,6 +53,7 @@ rt_Data_t rt_Data_f64(double val)
 #include "runtime/data/DataList.c.h"
 #include "runtime/data/DataStr.c.h"
 #include "runtime/data/DataMap.c.h"
+#include "runtime/data/GarbageColl.c.h"
 
 rt_Data_t rt_Data_str(rt_DataStr_t *str)
 {

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -136,20 +136,20 @@ void rt_Data_copy(rt_Data_t *var)
     }
 }
 
-void rt_Data_destroy(rt_Data_t *var)
+void rt_Data_destroy_circular(rt_Data_t *var, bool flag)
 {
     switch (var->type) {
         case rt_DATA_TYPE_STR:
         case rt_DATA_TYPE_INTERP_STR:
-            rt_DataStr_destroy(&var->data.str);
+            rt_DataStr_destroy_circular(&var->data.str, flag);
             if (!var->data.str) *var = rt_Data_null();
             break;
         case rt_DATA_TYPE_LST:
-            rt_DataList_destroy(&var->data.lst);
+            rt_DataList_destroy_circular(&var->data.lst, flag);
             if (!var->data.lst) *var = rt_Data_null();
             break;
         case rt_DATA_TYPE_MAP:
-            rt_DataMap_destroy(&var->data.mp);
+            rt_DataMap_destroy_circular(&var->data.mp, flag);
             if (!var->data.mp) *var = rt_Data_null();
             break;
         case rt_DATA_TYPE_ANY:
@@ -165,6 +165,11 @@ void rt_Data_destroy(rt_Data_t *var)
                corrupts data in case *var points to a rt_ global var */
             break;
     }
+}
+
+void rt_Data_destroy(rt_Data_t *var)
+{
+    rt_Data_destroy_circular(var, false);
 }
 
 bool rt_Data_isnull(const rt_Data_t var)

--- a/src/runtime/data/DataList.c.h
+++ b/src/runtime/data/DataList.c.h
@@ -45,14 +45,7 @@ void rt_DataList_destroy(rt_DataList_t **ptr)
     /* ref counting */
     --lst->rc;
     if (lst->rc < 0) lst->rc = 0;
-    if (lst->rc > 0) {
-        /* if rc > 0, check if the data has only cyclic references
-           if so, set rc to 0 to free the data */
-        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_list(lst))) {
-            lst->rc = 0;
-        }
-        else return;
-    }
+    if (lst->rc > 0) return;
     /* free if rc 0 */
     for (int64_t i = 0; i < lst->length; i++)
         rt_Data_destroy(&lst->var[i]);

--- a/src/runtime/data/DataList.c.h
+++ b/src/runtime/data/DataList.c.h
@@ -12,6 +12,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataStr.h"
+#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 
 rt_DataList_t *rt_DataList_init()
@@ -44,7 +45,14 @@ void rt_DataList_destroy(rt_DataList_t **ptr)
     /* ref counting */
     --lst->rc;
     if (lst->rc < 0) lst->rc = 0;
-    if (lst->rc > 0) return;
+    if (lst->rc > 0) {
+        /* if rc > 0, check if the data has only cyclic references
+           if so, set rc to 0 to free the data */
+        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_list(lst))) {
+            lst->rc = 0;
+        }
+        else return;
+    }
     /* free if rc 0 */
     for (int64_t i = 0; i < lst->length; i++)
         rt_Data_destroy(&lst->var[i]);

--- a/src/runtime/data/DataList.c.h
+++ b/src/runtime/data/DataList.c.h
@@ -12,7 +12,6 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataStr.h"
-#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 
 rt_DataList_t *rt_DataList_init()
@@ -45,15 +44,7 @@ void rt_DataList_destroy(rt_DataList_t **ptr)
     /* ref counting */
     --lst->rc;
     if (lst->rc < 0) lst->rc = 0;
-    if (lst->rc > 0) {
-        /* if rc > 0, check if the data has only cyclic references
-           if so, set rc to 0 to free the data */
-        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_list(lst))) {
-            rt_data_GC_break_cycle(rt_Data_list(lst), rt_Data_list(lst));
-            lst->rc = 0;
-        }
-        else return;
-    }
+    if (lst->rc > 0) return;
     /* free if rc 0 */
     for (int64_t i = 0; i < lst->length; i++)
         rt_Data_destroy(&lst->var[i]);

--- a/src/runtime/data/DataList.c.h
+++ b/src/runtime/data/DataList.c.h
@@ -12,6 +12,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataStr.h"
+#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 
 rt_DataList_t *rt_DataList_init()
@@ -44,7 +45,15 @@ void rt_DataList_destroy(rt_DataList_t **ptr)
     /* ref counting */
     --lst->rc;
     if (lst->rc < 0) lst->rc = 0;
-    if (lst->rc > 0) return;
+    if (lst->rc > 0) {
+        /* if rc > 0, check if the data has only cyclic references
+           if so, set rc to 0 to free the data */
+        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_list(lst))) {
+            rt_data_GC_break_cycle(rt_Data_list(lst), rt_Data_list(lst));
+            lst->rc = 0;
+        }
+        else return;
+    }
     /* free if rc 0 */
     for (int64_t i = 0; i < lst->length; i++)
         rt_Data_destroy(&lst->var[i]);

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -12,7 +12,6 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/data/DataStr.h"
-#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 #include "tlib/khash/khash.h"
 
@@ -45,15 +44,7 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr)
     /* ref counting */
     --mp->rc;
     if (mp->rc < 0) mp->rc = 0;
-    if (mp->rc > 0) {
-        /* if rc > 0, check if the data has only cyclic references
-           if so, set rc to 0 to free the data */
-        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_map(mp))) {
-            rt_data_GC_break_cycle(rt_Data_map(mp), rt_Data_map(mp));
-            mp->rc = 0;
-        }
-        else return;
-    }
+    if (mp->rc > 0) return;
     /* free if rc 0, iterate through each entry and destroy it */
     for (khiter_t entry_it = kh_begin(mp->data_map); entry_it != kh_end(mp->data_map); ++entry_it) {
         if (!kh_exist(mp->data_map, entry_it)) continue;

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -12,6 +12,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/data/DataStr.h"
+#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 #include "tlib/khash/khash.h"
 
@@ -44,7 +45,14 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr)
     /* ref counting */
     --mp->rc;
     if (mp->rc < 0) mp->rc = 0;
-    if (mp->rc > 0) return;
+    if (mp->rc > 0) {
+        /* if rc > 0, check if the data has only cyclic references
+           if so, set rc to 0 to free the data */
+        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_map(mp))) {
+            mp->rc = 0;
+        }
+        else return;
+    }
     /* free if rc 0, iterate through each entry and destroy it */
     for (khiter_t entry_it = kh_begin(mp->data_map); entry_it != kh_end(mp->data_map); ++entry_it) {
         if (!kh_exist(mp->data_map, entry_it)) continue;

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -45,14 +45,7 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr)
     /* ref counting */
     --mp->rc;
     if (mp->rc < 0) mp->rc = 0;
-    if (mp->rc > 0) {
-        /* if rc > 0, check if the data has only cyclic references
-           if so, set rc to 0 to free the data */
-        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_map(mp))) {
-            mp->rc = 0;
-        }
-        else return;
-    }
+    if (mp->rc > 0) return;
     /* free if rc 0, iterate through each entry and destroy it */
     for (khiter_t entry_it = kh_begin(mp->data_map); entry_it != kh_end(mp->data_map); ++entry_it) {
         if (!kh_exist(mp->data_map, entry_it)) continue;

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -12,6 +12,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/data/DataStr.h"
+#include "runtime/data/GarbageColl.h"
 #include "runtime/io.h"
 #include "tlib/khash/khash.h"
 
@@ -44,7 +45,15 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr)
     /* ref counting */
     --mp->rc;
     if (mp->rc < 0) mp->rc = 0;
-    if (mp->rc > 0) return;
+    if (mp->rc > 0) {
+        /* if rc > 0, check if the data has only cyclic references
+           if so, set rc to 0 to free the data */
+        if (rt_data_GC_has_only_cyclic_refcnt(rt_Data_map(mp))) {
+            rt_data_GC_break_cycle(rt_Data_map(mp), rt_Data_map(mp));
+            mp->rc = 0;
+        }
+        else return;
+    }
     /* free if rc 0, iterate through each entry and destroy it */
     for (khiter_t entry_it = kh_begin(mp->data_map); entry_it != kh_end(mp->data_map); ++entry_it) {
         if (!kh_exist(mp->data_map, entry_it)) continue;

--- a/src/runtime/data/DataStr.c.h
+++ b/src/runtime/data/DataStr.c.h
@@ -36,14 +36,19 @@ void rt_DataStr_copy(rt_DataStr_t *str)
     rt_DataList_copy(str->var);
 }
 
-void rt_DataStr_destroy(rt_DataStr_t **ptr)
+void rt_DataStr_destroy_circular(rt_DataStr_t **ptr, bool flag)
 {
     if (!ptr || !*ptr) return;
-    rt_DataList_destroy(&(*ptr)->var);
+    rt_DataList_destroy_circular(&(*ptr)->var, flag);
     /* free wrapper only if the list inside was freed and nulled */
     if ((*ptr)->var) return;
     free(*ptr);
     *ptr = NULL;
+}
+
+void rt_DataStr_destroy(rt_DataStr_t **ptr)
+{
+    rt_DataStr_destroy_circular(ptr, false);
 }
 
 void rt_DataStr_append(rt_DataStr_t *str, char var)

--- a/src/runtime/data/GarbageColl.c.h
+++ b/src/runtime/data/GarbageColl.c.h
@@ -10,6 +10,7 @@
 #include "runtime/data/DataMap.h"
 #include "runtime/data/GarbageColl.h"
 
+
 typedef union {
     rt_DataStr_t *str;
     rt_DataList_t *lst;
@@ -41,6 +42,15 @@ bool rt_data_GC_has_only_cyclic_refcnt(const rt_Data_t var)
     else return false;
 
     int64_t count = rt_data_GC_cyclic_count(var);
+#ifdef GC_DEBUG
+    printf(
+        "type: %s, ref: %p, count: %ld, refcnt: %ld\n",
+        rt_Data_typename(var),
+        var.data.mp,
+        count,
+        refcnt
+    );
+#endif
     return count == refcnt;
 }
 
@@ -104,12 +114,14 @@ void rt_data_GC_cyclic_count_helper(
             if ( ref->type == rt_DATA_TYPE_STR
               || ref->type == rt_DATA_TYPE_INTERP_STR) {
                 if (ref->data.str == target.str) ++(*count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
             } else if (ref->type == rt_DATA_TYPE_LST) {
                 if (ref->data.lst == target.lst) ++(*count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
             } else if (ref->type == rt_DATA_TYPE_MAP) {
                 if (ref->data.mp == target.mp) ++(*count);
-            } else
-                rt_data_GC_cyclic_count_helper(*ref, target, count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
         }
     }
 
@@ -137,12 +149,14 @@ void rt_data_GC_cyclic_count_helper(
             if ( ref->type == rt_DATA_TYPE_STR
               || ref->type == rt_DATA_TYPE_INTERP_STR) {
                 if (ref->data.str == target.str) ++(*count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
             } else if (ref->type == rt_DATA_TYPE_LST) {
                 if (ref->data.lst == target.lst) ++(*count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
             } else if (ref->type == rt_DATA_TYPE_MAP) {
                 if (ref->data.mp == target.mp) ++(*count);
-            } else
-                rt_data_GC_cyclic_count_helper(*ref, target, count);
+                else rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
         }
     }
 }

--- a/src/runtime/data/GarbageColl.c.h
+++ b/src/runtime/data/GarbageColl.c.h
@@ -144,7 +144,6 @@ void rt_data_GC_cyclic_count_helper(
             } else
                 rt_data_GC_cyclic_count_helper(*ref, target, count);
         }
-        printf("\n");
     }
 }
 

--- a/src/runtime/data/GarbageColl.c.h
+++ b/src/runtime/data/GarbageColl.c.h
@@ -79,6 +79,14 @@ void rt_data_GC_cyclic_count_helper(
     /* use incomming node as default node */
     rt_Data_t node = node_;
 
+#ifdef GC_DEBUG
+    printf("type: %s, node: %p, target: %p\n",
+        rt_Data_typename(node),
+        (void*) node.data.mp,
+        (void*) target.mp
+    );
+#endif
+
     /* get inner list from string to prevent truncation into char
        in the process set node to the inner list */
     if (node.type == rt_DATA_TYPE_STR || node.type == rt_DATA_TYPE_INTERP_STR) {
@@ -119,22 +127,24 @@ void rt_data_GC_cyclic_count_helper(
             if (!entry) continue;
             const rt_Data_t *ref = &entry->value;
             if (!ref) continue;
+#ifdef GC_DEBUG
+            printf("    type: %s, ref: %p, target: %p\n",
+                rt_Data_typename(*ref),
+                (void*) ref->data.mp,
+                (void*) target.mp
+            );
+#endif
             if ( ref->type == rt_DATA_TYPE_STR
               || ref->type == rt_DATA_TYPE_INTERP_STR) {
                 if (ref->data.str == target.str) ++(*count);
             } else if (ref->type == rt_DATA_TYPE_LST) {
                 if (ref->data.lst == target.lst) ++(*count);
             } else if (ref->type == rt_DATA_TYPE_MAP) {
-                printf(
-                    "type: %s, ref: %p, target: %p\n",
-                    rt_Data_typename(*ref),
-                    ref->data.mp,
-                    target.mp
-                );
                 if (ref->data.mp == target.mp) ++(*count);
             } else
                 rt_data_GC_cyclic_count_helper(*ref, target, count);
         }
+        printf("\n");
     }
 }
 

--- a/src/runtime/data/GarbageColl.c.h
+++ b/src/runtime/data/GarbageColl.c.h
@@ -125,7 +125,12 @@ void rt_data_GC_cyclic_count_helper(
             } else if (ref->type == rt_DATA_TYPE_LST) {
                 if (ref->data.lst == target.lst) ++(*count);
             } else if (ref->type == rt_DATA_TYPE_MAP) {
-                printf("type: %s, ref: %p, target: %p\n", rt_Data_typename(*ref), ref, target.str);
+                printf(
+                    "type: %s, ref: %p, target: %p\n",
+                    rt_Data_typename(*ref),
+                    ref->data.mp,
+                    target.mp
+                );
                 if (ref->data.mp == target.mp) ++(*count);
             } else
                 rt_data_GC_cyclic_count_helper(*ref, target, count);

--- a/src/runtime/data/GarbageColl.c.h
+++ b/src/runtime/data/GarbageColl.c.h
@@ -1,0 +1,147 @@
+#ifndef RT_DATA_GARBAGECOLL_C_H
+#define RT_DATA_GARBAGECOLL_C_H
+
+#include "runtime/data/Data.h"
+#include "runtime/data/DataStr.h"
+#include "runtime/data/DataList.h"
+#include "runtime/data/DataMap.h"
+#include "runtime/data/GarbageColl.h"
+#include <stdint.h>
+
+typedef union {
+    rt_DataStr_t *str;
+    rt_DataList_t *lst;
+    rt_DataMap_t *mp;
+} rt_data_GC_cyclic_count_target_t;
+
+
+void rt_data_GC_cyclic_count_helper(
+    const rt_Data_t node,
+    const rt_data_GC_cyclic_count_target_t target,
+    int64_t *count
+);
+
+
+bool rt_data_GC_has_only_cyclic_refcnt(const rt_Data_t var)
+{
+    if (var.type != rt_DATA_TYPE_STR && var.type != rt_DATA_TYPE_INTERP_STR
+        && var.type != rt_DATA_TYPE_LST && var.type != rt_DATA_TYPE_MAP)
+            return false;
+
+    rt_data_GC_cyclic_count_target_t target;
+    int64_t refcnt = 0;
+
+    if (var.type == rt_DATA_TYPE_STR || var.type == rt_DATA_TYPE_INTERP_STR) {
+        target.str = var.data.str;
+        refcnt = var.data.str->var->rc;
+    }
+    else if (var.type == rt_DATA_TYPE_LST) {
+        target.lst = var.data.lst;
+        refcnt = var.data.lst->rc;
+    }
+    else if (var.type == rt_DATA_TYPE_MAP) {
+        target.mp = var.data.mp;
+        refcnt = var.data.mp->rc;
+    }
+    else return false;
+
+    int64_t count = rt_data_GC_cyclic_count(var);
+    return count == refcnt;
+}
+
+
+int64_t rt_data_GC_cyclic_count(const rt_Data_t var)
+{
+    if (var.type != rt_DATA_TYPE_STR && var.type != rt_DATA_TYPE_INTERP_STR
+        && var.type != rt_DATA_TYPE_LST && var.type != rt_DATA_TYPE_MAP)
+            return 0;
+
+    rt_data_GC_cyclic_count_target_t target;
+
+    if (var.type == rt_DATA_TYPE_STR || var.type == rt_DATA_TYPE_INTERP_STR)
+        target.str = var.data.str;
+    else if (var.type == rt_DATA_TYPE_LST)
+        target.lst = var.data.lst;
+    else if (var.type == rt_DATA_TYPE_MAP)
+        target.mp = var.data.mp;
+    else return 0;
+
+    int64_t count = 0;
+    rt_data_GC_cyclic_count_helper(var, target, &count);
+    return count;
+}
+
+
+void rt_data_GC_cyclic_count_helper(
+    const rt_Data_t node_,
+    const rt_data_GC_cyclic_count_target_t target,
+    int64_t *count
+) {
+    if (node_.type != rt_DATA_TYPE_STR && node_.type != rt_DATA_TYPE_INTERP_STR
+        && node_.type != rt_DATA_TYPE_LST && node_.type != rt_DATA_TYPE_MAP)
+            return;
+
+    /* use incomming node as default node */
+    rt_Data_t node = node_;
+
+    /* get inner list from string to prevent truncation into char
+       in the process set node to the inner list */
+    if (node.type == rt_DATA_TYPE_STR || node.type == rt_DATA_TYPE_INTERP_STR) {
+        node.data.lst = node.data.str->var;
+        node.type = rt_DATA_TYPE_LST;
+    }
+
+    /* go through all elements in the list and if the reference is a string
+       or a list or map, check if it is the same as the target and increment the
+       counter if it is */
+    if (node.type == rt_DATA_TYPE_LST) {
+        for (int64_t i = 0; i < rt_DataList_length(node.data.lst); ++i) {
+            const rt_Data_t *ref = rt_DataList_getref_errnull(node.data.lst, i);
+            if (!ref) continue;
+            if (ref->type == rt_DATA_TYPE_STR || ref->type == rt_DATA_TYPE_INTERP_STR) {
+                if (ref->data.str == target.str) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+            else if (ref->type == rt_DATA_TYPE_LST) {
+                if (ref->data.lst == target.lst) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+            else if (ref->type == rt_DATA_TYPE_MAP) {
+                if (ref->data.mp == target.mp) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+        }
+    }
+
+    /* go through all values in the map and if the reference is a string
+       or a list or map, check if it is the same as the target and increment the
+       counter if it is */
+    else if (node.type == rt_DATA_TYPE_MAP) {
+        for (
+            rt_DataMap_iter_t it = rt_DataMap_begin(node.data.mp);
+            it != rt_DataMap_end(node.data.mp);
+            ++it
+        ) {
+            if (!rt_DataMap_exists(node.data.mp, it)) continue;
+            const rt_DataMapEntry_t *entry = rt_DataMap_get(node.data.mp, it);
+            if (!entry) continue;
+            const rt_Data_t *ref = &entry->value;
+            if (ref->type == rt_DATA_TYPE_STR || ref->type == rt_DATA_TYPE_INTERP_STR) {
+                if (ref->data.str == target.str) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+            else if (ref->type == rt_DATA_TYPE_LST) {
+                if (ref->data.lst == target.lst) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+            else if (ref->type == rt_DATA_TYPE_MAP) {
+                if (ref->data.mp == target.mp) ++(*count);
+                rt_data_GC_cyclic_count_helper(*ref, target, count);
+            }
+        }
+    }
+}
+
+#else
+    #warning re-inclusion of module 'runtime/data/GarbageColl.c.h'
+#endif

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -12,6 +12,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     if (!strcmp(module, "dbg")) {
         if (!strcmp(fname, "typename")) return rt_fn_DBG_TYPENAME;
         if (!strcmp(fname, "refcnt"))   return rt_fn_DBG_REFCNT;
+        if (!strcmp(fname, "id"))       return rt_fn_DBG_ID;
     }
     if (!strcmp(module, "io")) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;
@@ -48,6 +49,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
         case rt_fn_DBG_REFCNT:    return rt_fn_dbg_refcnt();
+        case rt_fn_DBG_ID:        return rt_fn_dbg_id();
 
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -1,6 +1,8 @@
 #ifndef RT_FN_MODULE_DBG_C_H
 #define RT_FN_MODULE_DBG_C_H
 
+#include <stdint.h>
+
 #include "io.h"
 #include "runtime/data/Data.h"
 #include "runtime/data/DataStr.h"
@@ -44,6 +46,36 @@ rt_Data_t rt_fn_dbg_refcnt()
             return rt_Data_i64(1);
     }
     return rt_Data_i64(1);
+}
+
+rt_Data_t rt_fn_dbg_id()
+{
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
+    if (args.type != rt_DATA_TYPE_LST)
+        io_errndie("rt_fn_dbg_refcnt: "
+                   "received arguments list as type '%s'", rt_Data_typename(args));
+    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    void *id_ptr = NULL;
+    switch (data.type) {
+        case rt_DATA_TYPE_STR:
+        case rt_DATA_TYPE_INTERP_STR:
+            id_ptr = (void*) data.data.str->var;
+        case rt_DATA_TYPE_LST:
+            id_ptr = (void*) data.data.lst;
+        case rt_DATA_TYPE_MAP:
+            id_ptr = (void*) data.data.mp;
+        case rt_DATA_TYPE_BUL:
+        case rt_DATA_TYPE_CHR:
+        case rt_DATA_TYPE_I64:
+        case rt_DATA_TYPE_F64:
+        case rt_DATA_TYPE_ANY:
+        case rt_DATA_TYPE_PROC:
+            id_ptr = (void*) &data;
+    }
+    /* convert void* to hex pointer string */
+    char id_str[64];
+    sprintf(id_str, "%p", id_ptr);
+    return rt_Data_str(rt_DataStr_init(id_str));
 }
 
 #else

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -60,10 +60,13 @@ rt_Data_t rt_fn_dbg_id()
         case rt_DATA_TYPE_STR:
         case rt_DATA_TYPE_INTERP_STR:
             id_ptr = (void*) data.data.str->var;
+            break;
         case rt_DATA_TYPE_LST:
             id_ptr = (void*) data.data.lst;
+            break;
         case rt_DATA_TYPE_MAP:
             id_ptr = (void*) data.data.mp;
+            break;
         case rt_DATA_TYPE_BUL:
         case rt_DATA_TYPE_CHR:
         case rt_DATA_TYPE_I64:
@@ -71,6 +74,7 @@ rt_Data_t rt_fn_dbg_id()
         case rt_DATA_TYPE_ANY:
         case rt_DATA_TYPE_PROC:
             id_ptr = (void*) &data;
+            break;
     }
     /* convert void* to hex pointer string */
     char id_str[64];


### PR DESCRIPTION
- added gc to search for cyclic refs
- using the gc module to find circular ref in lists and maps
- added dbg:id inbuilt fn
- code refactor
- fixed bug in dbg:id impl
- gc: na
- gc: na
- minor bug: tostr(proc) displayed proc:module instead of module:proc
- bugfix: references werent being counted
- added fn to break circular refs
- moved cycle breaker into vartable
- Revert "moved cycle breaker into vartable"
- added flags that activate during scope cleanup and allows gc to find and break circular refs
- v0.7.1: cyclic refs cannot be created and such objects get set to null
