### PR TITLE
v0.10: refacored fn calls interface and added dbg:callproc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ make run ARGS="examples/helloworld.txt"
     - [ ] `dbg:rtsize`
     - [x] `dbg:refcnt`
     - [x] `dbg:id`
+    - [x] `dbg:callproc`
     - [ ] `dbg:filename`
     - [ ] `dbg:lineno`
     - [x] `io:print`

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -636,6 +636,7 @@ The language supports the following built-in functions (within built-in modules)
 - `dbg:typename` returns identifier name of one of the [global variables for types](#global-variables-for-types)
 - `dbg:refcnt` returns total number of references to an object
 - `dbg:id` returns hex string of the memory address of an object
+- `dbg:callproc` calls a procedure from a module
 
 #### Module `io`
 - `io:print` prints string form of data (calls `tostr`)

--- a/examples/callproc.txt
+++ b/examples/callproc.txt
@@ -1,0 +1,4 @@
+proc main start
+    var x = dbg:callproc(null, "io", "input", ["enter a number: ", i64]);
+    dbg:callproc(null, "io", "print", ["you entered:", x, lf]);
+end

--- a/include/globals.h
+++ b/include/globals.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#define VERSION "0.9 Alpha"
+#define VERSION "0.10 Alpha"
 #define AUTHORS "Aviruk Basak"
 #define GLOBAL_BYTES_BUFFER_LEN (128)
 

--- a/include/runtime/data/DataList.h
+++ b/include/runtime/data/DataList.h
@@ -13,6 +13,21 @@ struct rt_DataList_t {
     int64_t rc;
 };
 
+
+/* macro that takes a variable number of rt_Data_t type arguments
+   and calls rt_DataList_append for each item */
+#define rt_DataList_from(...)                               \
+    ({                                                      \
+        rt_Data_t args[] = { __VA_ARGS__ };                 \
+        size_t args_len = sizeof(args) / sizeof(rt_Data_t); \
+        rt_DataList_t *lst = rt_DataList_init();            \
+        for (size_t i = 0; i < args_len; i++) {             \
+            rt_DataList_append(lst, args[i]);               \
+        }                                                   \
+        lst;                                                \
+    })
+
+
 rt_DataList_t *rt_DataList_init();
 int64_t rt_DataList_length(const rt_DataList_t *lst);
 void rt_DataList_increfc(rt_DataList_t *lst);

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -28,6 +28,7 @@ typedef enum {
     rt_fn_DBG_FILENAME,  /* dbg:filename */
     rt_fn_DBG_LINENO,    /* dbg:lineno */
     rt_fn_DBG_ID,        /* dbg:id */
+    rt_fn_DBG_CALLPROC,  /* dbg:callproc */
 
     rt_fn_IO_PRINT,      /* io:print */
     rt_fn_IO_INPUT,      /* io:input */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -79,7 +79,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn);
 
 const rt_DataList_t *rt_fn_get_valid_args(int64_t min_expected_argc);
 
-void rt_fn_call_handler(
+rt_Data_t rt_fn_call_handler(
     const rt_Data_t context,
     const char *modulename,
     const char *procname,

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -77,4 +77,6 @@ typedef enum {
 rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const char *fname);
 rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn);
 
+const rt_DataList_t *rt_fn_get_valid_args(int64_t min_expected_argc);
+
 #endif

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -79,4 +79,11 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn);
 
 const rt_DataList_t *rt_fn_get_valid_args(int64_t min_expected_argc);
 
+void rt_fn_call_handler(
+    const rt_Data_t context,
+    const char *modulename,
+    const char *procname,
+    const rt_DataList_t *args
+);
+
 #endif

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -83,7 +83,7 @@ void rt_fn_call_handler(
     const rt_Data_t context,
     const char *modulename,
     const char *procname,
-    const rt_DataList_t *args
+    rt_DataList_t *args
 );
 
 #endif

--- a/include/runtime/functions/module_dbg.h
+++ b/include/runtime/functions/module_dbg.h
@@ -6,5 +6,6 @@
 rt_Data_t rt_fn_dbg_typename();
 rt_Data_t rt_fn_dbg_refcnt();
 rt_Data_t rt_fn_dbg_id();
+rt_Data_t rt_fn_dbg_callproc();
 
 #endif

--- a/include/runtime/operators.h
+++ b/include/runtime/operators.h
@@ -32,7 +32,6 @@ void rt_op_plus                 (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_rbrace_angular       (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_tilde                (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_fnargs_indexing      (const rt_Data_t *lhs, const rt_Data_t *rhs);
-void rt_op_fncall_handler       (const rt_Data_t context, const ast_Identifier_t *module, const ast_Identifier_t *proc, rt_Data_t args);
 void rt_op_fncall               (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_indexing             (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_nop                  (const rt_Data_t *lhs);

--- a/include/runtime/operators.h
+++ b/include/runtime/operators.h
@@ -32,6 +32,7 @@ void rt_op_plus                 (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_rbrace_angular       (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_tilde                (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_fnargs_indexing      (const rt_Data_t *lhs, const rt_Data_t *rhs);
+void rt_op_fncall_handler       (const rt_Data_t context, const ast_Identifier_t *module, const ast_Identifier_t *proc, rt_Data_t args);
 void rt_op_fncall               (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_indexing             (const rt_Data_t *lhs, const rt_Data_t *rhs);
 void rt_op_nop                  (const rt_Data_t *lhs);

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -56,6 +56,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
         case rt_fn_DBG_REFCNT:    return rt_fn_dbg_refcnt();
         case rt_fn_DBG_ID:        return rt_fn_dbg_id();
+        case rt_fn_DBG_CALLPROC:  return rt_fn_dbg_callproc();
 
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -86,7 +86,7 @@ void rt_fn_call_handler(
     const rt_Data_t context,
     const char *modulename,
     const char *procname,
-    const rt_DataList_t *args
+    rt_DataList_t *args
 ) {
     ast_Identifier_t *module = ast_Identifier(strdup(modulename));
     ast_Identifier_t *proc = ast_Identifier(strdup(procname));

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -18,6 +18,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "typename")) return rt_fn_DBG_TYPENAME;
         if (!strcmp(fname, "refcnt"))   return rt_fn_DBG_REFCNT;
         if (!strcmp(fname, "id"))       return rt_fn_DBG_ID;
+        if (!strcmp(fname, "callproc")) return rt_fn_DBG_CALLPROC;
     }
     if (!strcmp(module, "io")) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -1,8 +1,10 @@
+#include <inttypes.h>
 #include <string.h>
 
 #include "io.h"
 #include "runtime/data/Data.h"
 #include "runtime/functions.h"
+#include "runtime/io.h"
 
 rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const char *fname)
 {
@@ -61,4 +63,18 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
             break;
     }
     return rt_Data_null();
+}
+
+const rt_DataList_t *rt_fn_get_valid_args(int64_t min_expected_argc)
+{
+    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
+    if (args.type != rt_DATA_TYPE_LST)
+        io_errndie("rt_fn_get_valid_args: "
+                   "received arguments list as type '%s'", rt_Data_typename(args));
+    if (rt_DataList_length(args.data.lst) < min_expected_argc)
+        rt_throw(
+            "expected at least %" PRId64 " arguments, received %" PRId64,
+            min_expected_argc, rt_DataList_length(args.data.lst)
+        );
+    return args.data.lst;
 }

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -82,7 +82,7 @@ const rt_DataList_t *rt_fn_get_valid_args(int64_t min_expected_argc)
     return args.data.lst;
 }
 
-void rt_fn_call_handler(
+rt_Data_t rt_fn_call_handler(
     const rt_Data_t context,
     const char *modulename,
     const char *procname,
@@ -129,5 +129,5 @@ void rt_fn_call_handler(
 
     ast_Identifier_destroy(&module);
     ast_Identifier_destroy(&proc);
-    rt_VarTable_pop_proc();
+    return rt_VarTable_pop_proc();
 }

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -9,6 +9,7 @@
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/functions.h"
+#include "runtime/io.h"
 #include "runtime/functions/module_dbg.h"
 #include "runtime/VarTable.h"
 
@@ -72,6 +73,45 @@ rt_Data_t rt_fn_dbg_id()
     char id_str[64];
     sprintf(id_str, "%p", id_ptr);
     return rt_Data_str(rt_DataStr_init(id_str));
+}
+
+rt_Data_t rt_fn_dbg_callproc()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(4);
+
+    const rt_Data_t context = *rt_DataList_getref(args, 0);
+
+    const rt_Data_t module = *rt_DataList_getref(args, 1);
+    /* module should be string */
+    if (module.type != rt_DATA_TYPE_STR) {
+        rt_throw("invalid type for module name: '%s', expected 'str'", rt_Data_typename(module));
+    }
+
+    const rt_Data_t proc = *rt_DataList_getref(args, 2);
+    /* proc should be string */
+    if (proc.type != rt_DATA_TYPE_STR) {
+        rt_throw("invalid type for procedure name: '%s', expected 'str'", rt_Data_typename(proc));
+    }
+
+    const rt_Data_t fnargs = *rt_DataList_getref(args, 3);
+    /* fnargs should be list */
+    if (fnargs.type != rt_DATA_TYPE_LST) {
+        rt_throw("invalid type for procedure arguments: '%s', expected 'lst'", rt_Data_typename(fnargs));
+    }
+
+    /* call procedure */
+    char *module_str = rt_Data_tostr(module);
+    char *proc_str = rt_Data_tostr(proc);
+    rt_Data_t ret = rt_fn_call_handler(
+        context,
+        module_str,
+        module_str,
+        fnargs.data.lst
+    );
+
+    free(module_str);
+    free(proc_str);
+    return ret;
 }
 
 #else

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -105,7 +105,7 @@ rt_Data_t rt_fn_dbg_callproc()
     rt_Data_t ret = rt_fn_call_handler(
         context,
         module_str,
-        module_str,
+        proc_str,
         fnargs.data.lst
     );
 

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -8,27 +8,22 @@
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataMap.h"
+#include "runtime/functions.h"
 #include "runtime/functions/module_dbg.h"
 #include "runtime/VarTable.h"
 
 rt_Data_t rt_fn_dbg_typename()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_dbg_typename: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     const char *tname= rt_Data_typename(data);
     return rt_Data_str(rt_DataStr_init(tname));
 }
 
 rt_Data_t rt_fn_dbg_refcnt()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_dbg_refcnt: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     switch (data.type) {
         case rt_DATA_TYPE_STR:
         case rt_DATA_TYPE_INTERP_STR:
@@ -50,11 +45,8 @@ rt_Data_t rt_fn_dbg_refcnt()
 
 rt_Data_t rt_fn_dbg_id()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_dbg_refcnt: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     void *id_ptr = NULL;
     switch (data.type) {
         case rt_DATA_TYPE_STR:

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -27,13 +27,10 @@ int rt_fn_io_input_str(char **val);
 
 rt_Data_t rt_fn_io_print()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_io_print: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
     int bytes = 0;
-    for (int i = 0; i < rt_DataList_length(args.data.lst); ++i) {
-        const rt_Data_t data = *rt_DataList_getref(args.data.lst, i);
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
         /* if (rt_Data_isnull(data)) continue; */
         /* print a space before data conditions:
            - no space before 1st element
@@ -50,12 +47,9 @@ rt_Data_t rt_fn_io_print()
 
 rt_Data_t rt_fn_io_input()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_io_input: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t prompt = *rt_DataList_getref(args.data.lst, 0);
-    const rt_Data_t type_ = *rt_DataList_getref(args.data.lst, 1);
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+    const rt_Data_t prompt = *rt_DataList_getref(args, 0);
+    const rt_Data_t type_ = *rt_DataList_getref(args, 1);
     rt_Data_t ret = rt_Data_null();
     if (type_.type != rt_DATA_TYPE_I64) {
         char *s = rt_Data_tostr(type_);

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -40,7 +40,26 @@ rt_Data_t rt_fn_io_print()
             /* i is not 1st element BUT if data is character it should not be lf */
             (i > 0 && data.type == rt_DATA_TYPE_CHR && data.data.chr != '\n'))
                 printf(" ");
-        bytes += rt_Data_print(data);
+
+        /* call tostr to convert data to string
+           since this goes through the call handler, it also goes
+           through the call stack limit check of the VarTable
+           and thus prevents segfaults on circular refs */
+        rt_Data_t str = rt_fn_call_handler(
+            rt_Data_null(),
+            "", "tostr",
+            rt_DataList_from(data)
+        );
+
+        /* print the string form of data */
+        char *data_str = rt_Data_tostr(str);
+        bytes += printf("%s", data_str);
+
+        /* free the string form of data
+           note that the returned data is not freed coz
+           the accumulator owns it an it'll be freed anyway
+           whe the accumulator lets go of it */
+        free(data_str);
     }
     return rt_Data_i64(bytes);
 }
@@ -67,7 +86,14 @@ rt_Data_t rt_fn_io_input()
             "valid parameters are bul, chr, i64, f64 or str\n"
             "respective values are %d, %d, %d, %d or %d",
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
-    rt_Data_print(prompt);
+
+    /* call io:print and display prompt */
+    rt_fn_call_handler(
+        rt_Data_null(),
+        "io", "print",
+        rt_DataList_from(prompt)
+    );
+
     switch (type) {
         case rt_DATA_TYPE_BUL: {
             bool val = false;

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -41,10 +41,7 @@ rt_Data_t rt_fn_io_print()
             (i > 0 && data.type == rt_DATA_TYPE_CHR && data.data.chr != '\n'))
                 printf(" ");
 
-        /* call tostr to convert data to string
-           since this goes through the call handler, it also goes
-           through the call stack limit check of the VarTable
-           and thus prevents segfaults on circular refs */
+        /* call tostr to convert data to string */
         rt_Data_t str = rt_fn_call_handler(
             rt_Data_null(),
             "", "tostr",

--- a/src/runtime/functions/module_it.c.h
+++ b/src/runtime/functions/module_it.c.h
@@ -6,16 +6,14 @@
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataMap.h"
+#include "runtime/functions.h"
 #include "runtime/functions/module_it.h"
 #include "runtime/VarTable.h"
 
 rt_Data_t rt_fn_it_len()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_it_len: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     switch (data.type) {
         case rt_DATA_TYPE_STR:
         case rt_DATA_TYPE_INTERP_STR:

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -7,26 +7,21 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataList.h"
+#include "runtime/functions.h"
 #include "runtime/functions/nomodule.h"
 #include "runtime/VarTable.h"
 
 rt_Data_t rt_fn_isnull()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_isnull: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     return rt_Data_bul(rt_Data_isnull(data));
 }
 
 rt_Data_t rt_fn_tostr()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_tostr: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     char *strdata = rt_Data_tostr(data);
     const rt_Data_t retdata = rt_Data_str(rt_DataStr_init(strdata));
     free(strdata);
@@ -36,11 +31,8 @@ rt_Data_t rt_fn_tostr()
 
 rt_Data_t rt_fn_type()
 {
-    rt_Data_t args = *rt_VarTable_getref(RT_VTABLE_ARGSVAR);
-    if (args.type != rt_DATA_TYPE_LST)
-        io_errndie("rt_fn_type: "
-                   "received arguments list as type '%s'", rt_Data_typename(args));
-    const rt_Data_t data = *rt_DataList_getref(args.data.lst, 0);
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
     switch (data.type) {
         case rt_DATA_TYPE_BUL:
             return rt_VarTable_typeid_bul;

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -28,46 +28,15 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     rt_Data_t context = lhs->data.proc.context
         ? *lhs->data.proc.context
         : rt_Data_null();
-    rt_op_fncall_handler(context, lhs->data.proc.modulename, lhs->data.proc.procname, *rhs);
+    rt_fn_call_handler(
+        context,
+        lhs->data.proc.modulename->identifier_name,
+        lhs->data.proc.procname->identifier_name,
+        rhs->data.lst
+    );
     /* set no data to accumulator as data is already set by procedure called above
        return early to prevent accumulator being modified by some other code */
     return;
-}
-
-void rt_op_fncall_handler(const rt_Data_t context, const ast_Identifier_t *module, const ast_Identifier_t *proc, rt_Data_t args)
-{
-    /* get code as AST from user defined function */
-    const ast_Statements_t *code = ast_util_ModuleAndProcTable_get_code(module, proc);
-    /* get a descriptor to in-built function */
-    const rt_fn_FunctionDescriptor_t fn = rt_fn_FunctionsList_getfn(
-        module->identifier_name, proc->identifier_name);
-
-    const char *currfile = NULL;
-    /* update metadata to new module and function */
-    if (code) {
-        currfile = ast_util_ModuleAndProcTable_get_filename(module, proc);
-    } else if (fn != rt_fn_UNDEFINED) {
-        currfile = module->identifier_name;
-    } else {
-        rt_throw("undefined procedure '%s:%s'",
-            module->identifier_name, proc->identifier_name);
-    }
-    rt_VarTable_push_proc(module, proc, currfile);
-    /* store fn args into agrs location */
-    rt_VarTable_create(RT_VTABLE_ARGSVAR, args, true, false);
-    rt_VarTable_create(RT_VTABLE_CONTEXTVAR, context, true, false);
-    if (code) {
-        /* call user defined function */
-        rt_ControlStatus_t ctrl = rt_eval_Statements(code);
-        if (ctrl == rt_CTRL_BREAK)
-            rt_throw("unexpected `break` statement outside loop");
-        if (ctrl == rt_CTRL_CONTINUE)
-            rt_throw("unexpected `continue` statement outside loop");
-    } else {
-        /* call in-built function */
-        rt_VarTable_acc_setval(rt_fn_FunctionsList_call(fn));
-    }
-    rt_VarTable_pop_proc();
 }
 
 #else

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -13,8 +13,6 @@
 #include "runtime/operators.h"
 #include "runtime/VarTable.h"
 
-void rt_op_fncall_handler(const rt_Data_t context, const ast_Identifier_t *module, const ast_Identifier_t *proc, rt_Data_t args);
-
 void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     if (lhs->type != rt_DATA_TYPE_PROC)
         rt_throw("cannot make procedure call to type '%s'", rt_Data_typename(*lhs));


### PR DESCRIPTION
- refactor: moved fn args validator to seperate fn
- added initializer list macro for rt_DataList_t
- mv rt_op_fncall_handler to globally visible header file
- mv rt_op_fncall_handler to generic rt_fn_call_handler
- passign args list as non-const to rt_fn_call_handler
- rt_fn_call_handler returns rt_Data_t from accumulator
- using rt_fn_call_handler instead of direct fn in io:print and io:input impl
- na
- added a dbg:callproc method to call a proc based on context, modulename, procname and args list
- bugfix
- v0.10
- updated docs
