### PR TITLE
v0.11: added more modules and in-built fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ make run ARGS="examples/helloworld.txt"
     - [x] `isnull`
     - [x] `tostr`
     - [x] `type`
+    - [x] `cast`
     - [x] `dbg:typename`
     - [ ] `dbg:rtsize`
     - [x] `dbg:refcnt`
@@ -102,7 +103,6 @@ make run ARGS="examples/helloworld.txt"
     - [x] `chr:islower`
     - [x] `chr:isupper`
     - [x] `chr:isspace`
-    - [x] `chr:tolower`
     - [x] `chr:max`
     - [x] `chr:min`
     - [x] `i64:max`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ make run ARGS="examples/helloworld.txt"
     - [x] `isnull`
     - [x] `tostr`
     - [x] `type`
-    - [x] `clone`
     - [x] `dbg:typename`
     - [ ] `dbg:rtsize`
     - [x] `dbg:refcnt`
@@ -96,23 +95,24 @@ make run ARGS="examples/helloworld.txt"
     - [x] `io:fwrite`
     - [x] `io:fappend`
     - [x] `it:len`
-    - [ ] `chr:isdigit`
-    - [ ] `chr:isalpha`
-    - [ ] `chr:isalnum`
-    - [ ] `chr:islower`
-    - [ ] `chr:isupper`
-    - [ ] `chr:isspace`
-    - [ ] `chr:tolower`
-    - [ ] `chr:max`
-    - [ ] `chr:min`
+    - [x] `it:clone`
+    - [x] `chr:isdigit`
+    - [x] `chr:isalpha`
+    - [x] `chr:isalnum`
+    - [x] `chr:islower`
+    - [x] `chr:isupper`
+    - [x] `chr:isspace`
+    - [x] `chr:tolower`
+    - [x] `chr:max`
+    - [x] `chr:min`
     - [x] `i64:max`
     - [x] `i64:min`
     - [x] `f64:max`
     - [x] `f64:min`
     - [x] `str:equals`
     - [x] `str:compare`
-    - [ ] `str:tolower`
-    - [ ] `str:toupper`
+    - [x] `str:tolower`
+    - [x] `str:toupper`
     - [x] `str:append`
     - [x] `str:insert`
     - [x] `str:erase`
@@ -135,12 +135,12 @@ make run ARGS="examples/helloworld.txt"
     - [x] `lst:find`
     - [x] `lst:join`
     - [x] `lst:sort`
-    - [ ] `map:set`
-    - [ ] `map:get`
-    - [ ] `map:erase`
-    - [ ] `map:concat`
-    - [ ] `map:find`
-    - [ ] `map:keys`
+    - [x] `map:set`
+    - [x] `map:get`
+    - [x] `map:erase`
+    - [x] `map:concat`
+    - [x] `map:find`
+    - [x] `map:keys`
 
 ### List File
  - Each line of the list file has a single file path

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ make run ARGS="examples/helloworld.txt"
     - [x] `tostr`
     - [x] `type`
     - [x] `cast`
+    - [x] `assert:type`
+    - [x] `assert:equals`
+    - [x] `assert:notnull`
     - [x] `dbg:typename`
     - [ ] `dbg:rtsize`
     - [x] `dbg:refcnt`

--- a/README.md
+++ b/README.md
@@ -79,23 +79,6 @@ make run ARGS="examples/helloworld.txt"
 - [x] If-else
 - [ ] Operators
 - [x] Built-in functions
-    | -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map    |
-    |--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|--------|
-    | isnull | type    | typename | print   | len   | max     | max | max | equals  | equals  | -      |
-    | tostr  | equals  | refcnt   | input   | clone | min     | min | min | compare | compare | -      |
-    | type   | notnull | id       | fread   | -     | isdigit | -   | -   | tolower | -       | -      |
-    | cast   | -       | callproc | fwrite  | -     | isalpha | -   | -   | toupper | -       | -      |
-    | -      | -       | filename | fappend | -     | isalnum | -   | -   | append  | append  | set    |
-    | -      | -       | lineno   | -       | -     | islower | -   | -   | insert  | insert  | get    |
-    | -      | -       | -        | -       | -     | isupper | -   | -   | erase   | erase   | erase  |
-    | -      | -       | -        | -       | -     | isspace | -   | -   | concat  | concat  | concat |
-    | -      | -       | -        | -       | -     | -       | -   | -   | reverse | reverse | -      |
-    | -      | -       | -        | -       | -     | -       | -   | -   | substr  | sublist | keys   |
-    | -      | -       | -        | -       | -     | -       | -   | -   | find    | find    | find   |
-    | -      | -       | -        | -       | -     | -       | -   | -   | split   | join    | -      |
-    | -      | -       | -        | -       | -     | -       | -   | -   | toi64   | -       | -      |
-    | -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -      |
-    | -      | -       | -        | -       | -     | -       | -   | -   | sort    | sort    | -      |
 
 ### List File
  - Each line of the list file has a single file path

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ make run ARGS="examples/helloworld.txt"
     - [x] `dbg:refcnt`
     - [x] `dbg:id`
     - [x] `dbg:callproc`
-    - [ ] `dbg:filename`
-    - [ ] `dbg:lineno`
+    - [x] `dbg:filename`
+    - [x] `dbg:lineno`
     - [x] `io:print`
     - [x] `io:input`
     - [x] `io:fread`

--- a/README.md
+++ b/README.md
@@ -91,16 +91,27 @@ make run ARGS="examples/helloworld.txt"
     - [ ] `dbg:lineno`
     - [x] `io:print`
     - [x] `io:input`
+    - [ ] `io:fread`
+    - [ ] `io:fwrite`
+    - [ ] `io:fappend`
     - [x] `it:len`
     - [ ] `chr:isdigit`
     - [ ] `chr:isalpha`
     - [ ] `chr:isalnum`
-    - [ ] `i64:maxval`
-    - [ ] `i64:minval`
-    - [ ] `f64:maxval`
-    - [ ] `f64:minval`
+    - [ ] `chr:islower`
+    - [ ] `chr:isupper`
+    - [ ] `chr:isspace`
+    - [ ] `chr:tolower`
+    - [ ] `chr:max`
+    - [ ] `chr:min`
+    - [ ] `i64:max`
+    - [ ] `i64:min`
+    - [ ] `f64:max`
+    - [ ] `f64:min`
     - [x] `str:equals`
     - [x] `str:compare`
+    - [ ] `str:tolower`
+    - [ ] `str:toupper`
     - [x] `str:append`
     - [x] `str:insert`
     - [x] `str:erase`
@@ -123,7 +134,8 @@ make run ARGS="examples/helloworld.txt"
     - [x] `lst:find`
     - [x] `lst:join`
     - [x] `lst:sort`
-    - [ ] `map:insert`
+    - [ ] `map:set`
+    - [ ] `map:get`
     - [ ] `map:erase`
     - [ ] `map:concat`
     - [ ] `map:find`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To learn more about the language, read [`docs/LanguageDocs.md`](docs/LanguageDoc
 #### Windows
 - Download [`Git Bash`](https://git-scm.com/)
 - Install Git Bash. Now you can run bash on Windows.
-- Download [`make`](https://gnuwin32.sourceforge.net/packages/make.htm)
+- Download [`Make`](https://gnuwin32.sourceforge.net/packages/make.htm)
 - Download [`Bison`](https://gnuwin32.sourceforge.net/packages/bison.htm)
 - Download [`MinGW`](https://github.com/skeeto/w64devkit/releases)
 - Extract the files and place them in some folder

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ make run ARGS="examples/helloworld.txt"
     - [x] `isnull`
     - [x] `tostr`
     - [x] `type`
+    - [x] `clone`
     - [x] `dbg:typename`
     - [ ] `dbg:rtsize`
     - [x] `dbg:refcnt`

--- a/README.md
+++ b/README.md
@@ -78,72 +78,24 @@ make run ARGS="examples/helloworld.txt"
 - [x] Break and continue
 - [x] If-else
 - [ ] Operators
-- [ ] Built-in functions
-    - [x] `isnull`
-    - [x] `tostr`
-    - [x] `type`
-    - [x] `cast`
-    - [x] `assert:type`
-    - [x] `assert:equals`
-    - [x] `assert:notnull`
-    - [x] `dbg:typename`
-    - [ ] `dbg:rtsize`
-    - [x] `dbg:refcnt`
-    - [x] `dbg:id`
-    - [x] `dbg:callproc`
-    - [x] `dbg:filename`
-    - [x] `dbg:lineno`
-    - [x] `io:print`
-    - [x] `io:input`
-    - [x] `io:fread`
-    - [x] `io:fwrite`
-    - [x] `io:fappend`
-    - [x] `it:len`
-    - [x] `it:clone`
-    - [x] `chr:isdigit`
-    - [x] `chr:isalpha`
-    - [x] `chr:isalnum`
-    - [x] `chr:islower`
-    - [x] `chr:isupper`
-    - [x] `chr:isspace`
-    - [x] `chr:max`
-    - [x] `chr:min`
-    - [x] `i64:max`
-    - [x] `i64:min`
-    - [x] `f64:max`
-    - [x] `f64:min`
-    - [x] `str:equals`
-    - [x] `str:compare`
-    - [x] `str:tolower`
-    - [x] `str:toupper`
-    - [x] `str:append`
-    - [x] `str:insert`
-    - [x] `str:erase`
-    - [x] `str:concat`
-    - [x] `str:reverse`
-    - [x] `str:substr`
-    - [x] `str:find`
-    - [x] `str:split`
-    - [x] `str:toi64`
-    - [x] `str:tof64`
-    - [x] `str:sort`
-    - [x] `lst:equals`
-    - [x] `lst:compare`
-    - [x] `lst:append`
-    - [x] `lst:insert`
-    - [x] `lst:erase`
-    - [x] `lst:concat`
-    - [x] `lst:reverse`
-    - [x] `lst:sublist`
-    - [x] `lst:find`
-    - [x] `lst:join`
-    - [x] `lst:sort`
-    - [x] `map:set`
-    - [x] `map:get`
-    - [x] `map:erase`
-    - [x] `map:concat`
-    - [x] `map:find`
-    - [x] `map:keys`
+- [x] Built-in functions
+    | -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map    |
+    |--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|--------|
+    | isnull | type    | typename | print   | len   | max     | max | max | equals  | equals  | -      |
+    | tostr  | equals  | refcnt   | input   | clone | min     | min | min | compare | compare | -      |
+    | type   | notnull | id       | fread   | -     | isdigit | -   | -   | tolower | -       | -      |
+    | cast   | -       | callproc | fwrite  | -     | isalpha | -   | -   | toupper | -       | -      |
+    | -      | -       | filename | fappend | -     | isalnum | -   | -   | append  | append  | set    |
+    | -      | -       | lineno   | -       | -     | islower | -   | -   | insert  | insert  | get    |
+    | -      | -       | -        | -       | -     | isupper | -   | -   | erase   | erase   | erase  |
+    | -      | -       | -        | -       | -     | isspace | -   | -   | concat  | concat  | concat |
+    | -      | -       | -        | -       | -     | -       | -   | -   | reverse | reverse | -      |
+    | -      | -       | -        | -       | -     | -       | -   | -   | substr  | sublist | keys   |
+    | -      | -       | -        | -       | -     | -       | -   | -   | find    | find    | find   |
+    | -      | -       | -        | -       | -     | -       | -   | -   | split   | join    | -      |
+    | -      | -       | -        | -       | -     | -       | -   | -   | toi64   | -       | -      |
+    | -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -      |
+    | -      | -       | -        | -       | -     | -       | -   | -   | sort    | sort    | -      |
 
 ### List File
  - Each line of the list file has a single file path
@@ -186,3 +138,21 @@ shsc -tf ast.json examples/factorial.txt
 
 ### Todo
 - Implement various operators and type coercion systems.
+
+| -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map    |
+|--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|--------|
+| isnull | type    | typename | print   | len   | isdigit | max | max | equals  | equals  | set    |
+| tostr  | equals  | refcnt   | input   | clone | isalpha | min | min | compare | compare | get    |
+| type   | notnull | id       | fread   | -     | isalnum | -   | -   | tolower | append  | erase  |
+| cast   | -       | callproc | fwrite  | -     | islower | -   | -   | toupper | insert  | concat |
+| -      | -       | filename | fappend | -     | isupper | -   | -   | append  | erase   | find   |
+| -      | -       | lineno   | -       | -     | isspace | -   | -   | insert  | concat  | keys   |
+| -      | -       | -        | -       | -     | max     | -   | -   | erase   | reverse | -      |
+| -      | -       | -        | -       | -     | min     | -   | -   | concat  | sublist | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | reverse | find    | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | substr  | join    | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | find    | sort    | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | split   | -       | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | toi64   | -       | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | sort    | -       | -      |

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ make run ARGS="examples/helloworld.txt"
     - [ ] `dbg:lineno`
     - [x] `io:print`
     - [x] `io:input`
-    - [ ] `io:fread`
-    - [ ] `io:fwrite`
-    - [ ] `io:fappend`
+    - [x] `io:fread`
+    - [x] `io:fwrite`
+    - [x] `io:fappend`
     - [x] `it:len`
     - [ ] `chr:isdigit`
     - [ ] `chr:isalpha`
@@ -105,10 +105,10 @@ make run ARGS="examples/helloworld.txt"
     - [ ] `chr:tolower`
     - [ ] `chr:max`
     - [ ] `chr:min`
-    - [ ] `i64:max`
-    - [ ] `i64:min`
-    - [ ] `f64:max`
-    - [ ] `f64:min`
+    - [x] `i64:max`
+    - [x] `i64:min`
+    - [x] `f64:max`
+    - [x] `f64:min`
     - [x] `str:equals`
     - [x] `str:compare`
     - [ ] `str:tolower`

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -74,8 +74,12 @@ Shsc is a dynamically and weakly typed language with coercion rules that make se
     - [Module `dbg`](#module-dbg)
     - [Module `io`](#module-io)
     - [Module `it`](#module-it)
+    - [Module `chr`](#module-chr)
+    - [Module `i64`](#module-i64)
+    - [Module `f64`](#module-f64)
     - [Module `str`](#module-str)
     - [Module `lst`](#module-lst)
+    - [Module `map`](#module-map)
 
 ## File structure
 The interpreter accepts file paths as command-line arguments for the files you want to run.
@@ -637,16 +641,43 @@ The language supports the following built-in procedures (within built-in modules
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string
+- `dbg:rtsize(any)` returns size of data in bytes
 - `dbg:refcnt(any)` returns total number of references to an object
 - `dbg:id(any)` returns hex string of the memory address of an object
 - `dbg:callproc(any, str, str, lst)` calls a procedure from a module; the first argument is the context object, the second argument is the module name, the third argument is the procedure name, and the fourth argument is the list of arguments to the procedure
+- `dbg:filename()` returns filename of the source file where called
+- `dbg:lineno()` returns line number of the source file where called
 
 #### Module `io`
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
 - `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see [Global variables for types](#global-variables-for-types)
 
 #### Module `it`
-- `it:len` returns length of list, string or map, else returns `1`
+- `it:len(any)` returns length of list, string or map, else returns `1`
+
+#### Module `chr`
+- `chr:isdigit(chr)` returns true if character is a digit, else false
+- `chr:isalpha(chr)` returns true if character is a letter, else false
+- `chr:isalnum(chr)` returns true if character is a letter or digit, else false
+- `chr:islower(chr)` returns true if character is a lowercase letter, else false
+- `chr:isupper(chr)` returns true if character is an uppercase letter, else false
+- `chr:isspace(chr)` returns true if character is a whitespace, else false
+- `chr:max()` returns the greatest possible character
+- `chr:max(chr, i64, f64, ...)` returns the greater of the numbers
+- `chr:min()` returns the smallest possible character
+- `chr:min(chr, i64, f64, ...)` returns the smaller of the numbers
+
+#### Module `i64`
+- `i64:max()` returns the greatest possible i64
+- `i64:max(chr, i64, f64, ...)` returns the greater of the numbers
+- `i64:min()` returns the smallest possible i64
+- `i64:min(chr, i64, f64, ...)` returns the smaller of the numbers
+
+#### Module `f64`
+- `f64:max()` returns the greatest possible f64
+- `f64:max(chr, i64, f64, ...)` returns the greater of the numbers
+- `f64:min()` returns the smallest possible f64
+- `f64:min(chr, i64, f64, ...)` returns the smaller of the numbers
 
 #### Module `str`
 `str:concat` is the only manupulative procedure that doesn't work in-place.
@@ -654,6 +685,8 @@ This means that it returns a new string instead of modifying the original string
 
 - `str:equals(str, str)` returns true if strings are equal, else false
 - `str:compare(str, str)` returns positive if first string is greater, negative if first string is smaller, else 0
+- `str:tolower(str)` converts a string to lowercase
+- `str:toupper(str)` converts a string to uppercase
 - `str:append(str, str)` appends second string to first string
 - `str:append(str, chr)` appends a single character to first string
 - `str:insert(str, i64, str)` inserts a string at index in first string

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -1,4 +1,4 @@
-**Last updated on Nov 11, 2023**
+**Last updated on Nov 12, 2023**
 
 The following is a documentation of the syntax and behaviour of the language.
 
@@ -640,10 +640,10 @@ The language supports the following built-in procedures (within built-in modules
 |--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|--------|
 | isnull | type    | typename | print   | len   | max     | max | max | equals  | equals  | -      |
 | tostr  | equals  | refcnt   | input   | clone | min     | min | min | compare | compare | -      |
-| type   | notnull | id       | fread   | -     | isdigit | -   | -   | tolower | -       | -      |
-| cast   | -       | callproc | fwrite  | -     | isalpha | -   | -   | toupper | -       | -      |
-| -      | -       | filename | fappend | -     | isalnum | -   | -   | append  | append  | set    |
-| -      | -       | lineno   | -       | -     | islower | -   | -   | insert  | insert  | get    |
+| type   | notnull | id       | fexists | -     | isdigit | -   | -   | tolower | -       | -      |
+| cast   | -       | callproc | fread   | -     | isalpha | -   | -   | toupper | -       | -      |
+| -      | -       | filename | fwrite  | -     | isalnum | -   | -   | append  | append  | set    |
+| -      | -       | lineno   | fappend | -     | islower | -   | -   | insert  | insert  | get    |
 | -      | -       | -        | -       | -     | isupper | -   | -   | erase   | erase   | erase  |
 | -      | -       | -        | -       | -     | isspace | -   | -   | concat  | concat  | concat |
 | -      | -       | -        | -       | -     | -       | -   | -   | reverse | reverse | -      |
@@ -675,8 +675,14 @@ The language supports the following built-in procedures (within built-in modules
 - `dbg:lineno()` returns line number of the source file where called
 
 #### Module `io`
+File I/O functions will not create a file if it doesn't exist.
+
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
 - `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see [global variables for types](#global-variables-for-types)
+- `io:fexists(str)` returns true if file exists, else false
+- `io:fread(str)` reads a file and returns a string; the first argument is the file path
+- `io:fwrite(str, str)` writes a string to a file; the first argument is the file path
+- `io:fappend(str, str)` appends a string to a file; the first argument is the file path
 
 #### Module `it`
 - `it:len(any)` returns length of list, string or map, else returns `1`

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -639,6 +639,7 @@ The language supports the following built-in procedures (within built-in modules
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of the [global variables for types](#global-variables-for-types)
+- `cast(any, i64)` casts data to a type; the second argument is one of the [global variables for types](#global-variables-for-types)
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string
@@ -651,7 +652,7 @@ The language supports the following built-in procedures (within built-in modules
 
 #### Module `io`
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
-- `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see [Global variables for types](#global-variables-for-types)
+- `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see [global variables for types](#global-variables-for-types)
 
 #### Module `it`
 - `it:len(any)` returns length of list, string or map, else returns `1`

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -729,7 +729,8 @@ This means that it returns a new map instead of modifying the original map.
 
 However, all map related procedures work using shallow copies, and no procedure is provided to create deep copies.
 
-- `map:insert(map, str, any)` inserts an item into a map; the first argument is the map, the second argument is the key, and the third argument is the value
+- `map:set(map, str, any)` sets a key-value pair in a map; the first argument is the map, the second argument is the key, and the third argument is the value
+- `map:get(map, str)` returns the value for a key in a map; the first argument is the map, and the second argument is the key
 - `map:erase(map, str)` erases an item from a map; the first argument is the map, and the second argument is the key
 - `map:concat(map, map)` concatenates two maps and returns a new map
 - `map:find(map, str)` returns true if key exists, else false

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -636,6 +636,24 @@ Also note how data is stringified during conversion to string (printing).
 ## Built-in procedures
 The language supports the following built-in procedures (within built-in modules)
 
+| -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map    |
+|--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|--------|
+| isnull | type    | typename | print   | len   | max     | max | max | equals  | equals  | -      |
+| tostr  | equals  | refcnt   | input   | clone | min     | min | min | compare | compare | -      |
+| type   | notnull | id       | fread   | -     | isdigit | -   | -   | tolower | -       | -      |
+| cast   | -       | callproc | fwrite  | -     | isalpha | -   | -   | toupper | -       | -      |
+| -      | -       | filename | fappend | -     | isalnum | -   | -   | append  | append  | set    |
+| -      | -       | lineno   | -       | -     | islower | -   | -   | insert  | insert  | get    |
+| -      | -       | -        | -       | -     | isupper | -   | -   | erase   | erase   | erase  |
+| -      | -       | -        | -       | -     | isspace | -   | -   | concat  | concat  | concat |
+| -      | -       | -        | -       | -     | -       | -   | -   | reverse | reverse | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | substr  | sublist | keys   |
+| -      | -       | -        | -       | -     | -       | -   | -   | find    | find    | find   |
+| -      | -       | -        | -       | -     | -       | -   | -   | split   | join    | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | toi64   | -       | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -      |
+| -      | -       | -        | -       | -     | -       | -   | -   | sort    | sort    | -      |
+
 #### Globally available
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -71,6 +71,7 @@ Shsc is a dynamically and weakly typed language with coercion rules that make se
         - [Example](#example-6)
 - [Built-in procedures](#built-in-procedures)
     - [Globally available](#globally-available)
+    - [Module `assert`](#module-assert)
     - [Module `dbg`](#module-dbg)
     - [Module `io`](#module-io)
     - [Module `it`](#module-it)
@@ -640,6 +641,11 @@ The language supports the following built-in procedures (within built-in modules
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of the [global variables for types](#global-variables-for-types)
 - `cast(any, i64)` casts data to a type; the second argument is one of the [global variables for types](#global-variables-for-types)
+
+#### Module `assert`
+- `assert:type(any, i64)` returns true if data is of the specified type, else throws an error
+- `assert:equals(any, any)` returns true if data is equal, else throws an error
+- `assert:notnull(any)` returns true if data is not `null`, else throws an error
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -639,7 +639,6 @@ The language supports the following built-in procedures (within built-in modules
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of the [global variables for types](#global-variables-for-types)
-- `clone(any)` returns a shallow copy of the data
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string
@@ -656,6 +655,7 @@ The language supports the following built-in procedures (within built-in modules
 
 #### Module `it`
 - `it:len(any)` returns length of list, string or map, else returns `1`
+- `it:clone(any)` returns a shallow copy of the data
 
 #### Module `chr`
 - `chr:isdigit(chr)` returns true if character is a digit, else false

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -638,6 +638,7 @@ The language supports the following built-in procedures (within built-in modules
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of the [global variables for types](#global-variables-for-types)
+- `clone(any)` returns a shallow copy of the data
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -642,7 +642,7 @@ The language supports the following built-in procedures (within built-in modules
 
 #### Module `dbg`
 - `dbg:typename(any)` returns type name of data as string
-- `dbg:rtsize(any)` returns size of data in bytes
+- `dbg:rtsize(any)` returns size of data in bytes; may be never implemented considering the computation will require recursive dfs traversal of composite data structures
 - `dbg:refcnt(any)` returns total number of references to an object
 - `dbg:id(any)` returns hex string of the memory address of an object
 - `dbg:callproc(any, str, str, lst)` calls a procedure from a module; the first argument is the context object, the second argument is the module name, the third argument is the procedure name, and the fourth argument is the list of arguments to the procedure

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -516,6 +516,7 @@ These variables must not be assigned to or else the user may face issues.
 - `str` i64 value indicating the str type
 - `lst` i64 value indicating the lst type
 - `map` i64 value indicating the map type
+- `proc` i64 value indicating the proc type
 
 The term `built-in` is more accurate for these and we will not call these *primitive*s.
 The language has built-in support for complex composite data structures which can be used using the literals syntax.

--- a/examples/clone.txt
+++ b/examples/clone.txt
@@ -1,0 +1,9 @@
+proc main start
+    var s = [1,2,3,4,5,6,7,8]
+    var s2 = it:clone(s)
+    io:print(s, lf)
+    io:print(s2, lf)
+    s[4] = 0
+    io:print(s, lf)
+    io:print(s2, lf)
+end

--- a/examples/fileio.txt
+++ b/examples/fileio.txt
@@ -1,0 +1,5 @@
+proc main start
+    io:print(io:fexists("./compile_flags.txt"), lf)
+    io:print(io:fexists("./src/compile_flags.txt"), lf)
+    io:print(io:fread("compile_flags.txt"), lf)
+end

--- a/examples/filenline.txt
+++ b/examples/filenline.txt
@@ -1,0 +1,4 @@
+proc main start
+    var a = 5
+    io:print(dbg:filename(), dbg:lineno(), lf)
+end

--- a/examples/lvalue.txt
+++ b/examples/lvalue.txt
@@ -1,0 +1,4 @@
+proc main start
+    var s = "hi there"
+    io:print(s, lf) = 5
+end

--- a/examples/testassert.txt
+++ b/examples/testassert.txt
@@ -1,0 +1,5 @@
+proc main start
+    assert:type({}, map)
+    assert:type([], lst)
+    assert:equals(1.0, 1)
+end

--- a/examples/testlst.txt
+++ b/examples/testlst.txt
@@ -5,7 +5,7 @@ proc main start
     # io:print(lst:compare(lst1, lst2), lf)
     io:print(lst:append(lst1, '_'), lf)
     io:print(lst:append(lst1, "power_"), lf)
-    io:print(lst:insert(lst1, 4, 'o'), lf)
+    io:print(lst:insert(lst1, 4, {}), lf)
     io:print(lst:insert(lst1, 4, "oo"), lf)
     io:print(lst:erase(lst1, 1, 3), lf)
     io:print(lst:concat(lst1, lst2), lf)

--- a/examples/testmap.txt
+++ b/examples/testmap.txt
@@ -1,0 +1,14 @@
+proc main start
+    var x = {}
+    map:set(x, "a", 1)
+    map:set(x, "b", 2)
+    map:set(x, "c", [1,2,3])
+    map:set(x, "d", 4)
+    map:set(x, "e", 5)
+    io:print(x, lf)
+    io:print(map:get(x, "a"), lf)
+    map:erase(x, "c")
+    io:print(x, lf)
+    io:print(map:find(x, "c"), lf)
+    io:print(map:keys(x), lf)
+end

--- a/examples/testnum.txt
+++ b/examples/testnum.txt
@@ -1,0 +1,14 @@
+proc main start
+    io:print(+chr:max(), +chr:min(), lf)
+    io:print(+chr:max(1, 'a', 11.5, 69.9), +chr:min(1, 'a', 11.5, 69.9), lf)
+    io:print(chr:isalpha('a'), chr:isalpha('1'), lf)
+    io:print(chr:isdigit('a'), chr:isdigit('1'), lf)
+    io:print(chr:isalnum('a'), chr:isalnum('1'), lf)
+    io:print(chr:islower('a'), chr:islower('A'), lf)
+    io:print(chr:isupper('a'), chr:isupper('A'), lf)
+    io:print(chr:isspace(' '), chr:isspace('a'), lf)
+    io:print(i64:max(), i64:min(), lf)
+    io:print(i64:max(1, 'a', 11.5, 69.9), i64:min(1, 'a', 11.5, 69.9), lf)
+    io:print(f64:max(), f64:min(), lf)
+    io:print(f64:max(1, 'a', 11.5, 69.9), f64:min(1, 'a', 11.5, 69.9), lf)
+end

--- a/examples/testnum.txt
+++ b/examples/testnum.txt
@@ -1,5 +1,5 @@
 proc main start
-    io:print(+chr:max(), +chr:min(), lf)
+    io:print(cast(chr:max(), i64), cast(chr:min(), i64), lf)
     io:print(+chr:max(1, 'a', 11.5, 69.9), +chr:min(1, 'a', 11.5, 69.9), lf)
     io:print(chr:isalpha('a'), chr:isalpha('1'), lf)
     io:print(chr:isdigit('a'), chr:isdigit('1'), lf)

--- a/examples/teststr.txt
+++ b/examples/teststr.txt
@@ -1,8 +1,10 @@
 proc main start
     var str1 = const "hell"
-    var str2 = "there"
+    var str2 = "THERE"
     io:print(str:equals(str1, str2), lf)
     io:print(str:compare(str1, str2), lf)
+    io:print(str:toupper(str1), lf)
+    io:print(str:tolower(str2), lf)
     io:print(str:append(str1, '_'), lf)
     io:print(str:append(str1, "power_"), lf)
     io:print(str:insert(str1, 4, 'o'), lf)

--- a/include/globals.h
+++ b/include/globals.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#define VERSION "0.10 Alpha"
+#define VERSION "0.11 Alpha"
 #define AUTHORS "Aviruk Basak"
 #define GLOBAL_BYTES_BUFFER_LEN (128)
 

--- a/include/runtime/VarTable.h
+++ b/include/runtime/VarTable.h
@@ -62,6 +62,7 @@ rt_Data_t rt_VarTable_rsv_lf,
           rt_VarTable_typeid_lst,
           rt_VarTable_typeid_any,
           rt_VarTable_typeid_map,
+          rt_VarTable_typeid_proc,
           rt_VarTable_rsv_null;
 
 /** create a new variable in the current scope */

--- a/include/runtime/data/Data.h
+++ b/include/runtime/data/Data.h
@@ -48,6 +48,7 @@ struct rt_Data_t {
     } data;
     bool is_const;
     bool is_weak;
+    bool lvalue;
     enum rt_DataType_t type;
 };
 

--- a/include/runtime/data/Data.h
+++ b/include/runtime/data/Data.h
@@ -82,6 +82,7 @@ int64_t rt_Data_compare(const rt_Data_t var1, const rt_Data_t var2);
 char *rt_Data_interp_str_parse(const char *str);
 bool rt_Data_tobool(const rt_Data_t var);
 char *rt_Data_tostr(const rt_Data_t var);
+rt_Data_t rt_Data_cast(const rt_Data_t var, enum rt_DataType_t type);
 const char *rt_Data_typename(const rt_Data_t var);
 bool rt_Data_assert_type(
     const rt_Data_t var,

--- a/include/runtime/data/Data.h
+++ b/include/runtime/data/Data.h
@@ -69,6 +69,8 @@ rt_Data_t rt_Data_null(void);
 void rt_Data_increfc(rt_Data_t *var);
 void rt_Data_decrefc(rt_Data_t *var);
 
+rt_Data_t rt_Data_clone(const rt_Data_t var);
+
 void rt_Data_destroy_circular(rt_Data_t *var, bool flag);
 void rt_Data_destroy(rt_Data_t *var);
 

--- a/include/runtime/data/DataStr.h
+++ b/include/runtime/data/DataStr.h
@@ -21,6 +21,8 @@ void rt_DataStr_decrefc(rt_DataStr_t *str);
 void rt_DataStr_destroy_circular(rt_DataStr_t **ptr, bool flag);
 void rt_DataStr_destroy(rt_DataStr_t **ptr);
 
+void rt_DataStr_toupper              (rt_DataStr_t *str);
+void rt_DataStr_tolower              (rt_DataStr_t *str);
 void rt_DataStr_append               (rt_DataStr_t *str, char ch);
 void rt_DataStr_concat               (rt_DataStr_t *str, const rt_DataStr_t *str2);
 void rt_DataStr_insert               (rt_DataStr_t *str, int64_t idx, char ch);

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -21,7 +21,6 @@ typedef enum {
     rt_fn_ISNULL,        /* isnull */
     rt_fn_TOSTR,         /* tostr */
     rt_fn_TYPE,          /* type */
-    rt_fn_CLONE,         /* clone */
 
     rt_fn_DBG_TYPENAME,  /* dbg:typename */
     rt_fn_DBG_RTSIZE,    /* dbg:rtsize */
@@ -38,6 +37,7 @@ typedef enum {
     rt_fn_IO_FAPPEND,    /* io:fappend */
 
     rt_fn_IT_LEN,        /* it:len */
+    rt_fn_IT_CLONE,      /* it:clone */
 
     rt_fn_CHR_ISDIGIT,   /* chr:isdigit */
     rt_fn_CHR_ISALPHA,   /* chr:isalpha */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -21,6 +21,7 @@ typedef enum {
     rt_fn_ISNULL,        /* isnull */
     rt_fn_TOSTR,         /* tostr */
     rt_fn_TYPE,          /* type */
+    rt_fn_CAST,          /* cast */
 
     rt_fn_DBG_TYPENAME,  /* dbg:typename */
     rt_fn_DBG_RTSIZE,    /* dbg:rtsize */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -25,28 +25,38 @@ typedef enum {
     rt_fn_DBG_TYPENAME,  /* dbg:typename */
     rt_fn_DBG_RTSIZE,    /* dbg:rtsize */
     rt_fn_DBG_REFCNT,    /* dbg:refcnt */
-    rt_fn_DBG_FILENAME,  /* dbg:filename */
-    rt_fn_DBG_LINENO,    /* dbg:lineno */
     rt_fn_DBG_ID,        /* dbg:id */
     rt_fn_DBG_CALLPROC,  /* dbg:callproc */
+    rt_fn_DBG_FILENAME,  /* dbg:filename */
+    rt_fn_DBG_LINENO,    /* dbg:lineno */
 
     rt_fn_IO_PRINT,      /* io:print */
     rt_fn_IO_INPUT,      /* io:input */
+    rt_fn_IO_FREAD,      /* io:fread */
+    rt_fn_IO_FWRITE,     /* io:fwrite */
+    rt_fn_IO_FAPPEND,    /* io:fappend */
 
     rt_fn_IT_LEN,        /* it:len */
 
     rt_fn_CHR_ISDIGIT,   /* chr:isdigit */
     rt_fn_CHR_ISALPHA,   /* chr:isalpha */
     rt_fn_CHR_ISALNUM,   /* chr:isalnum */
+    rt_fn_CHR_ISLOWER,   /* chr:islower */
+    rt_fn_CHR_ISUPPER,   /* chr:isupper */
+    rt_fn_CHR_ISSPACE,   /* chr:isspace */
+    rt_fn_CHR_MAX,       /* chr:max */
+    rt_fn_CHR_MIN,       /* chr:min */
 
-    rt_fn_I64_MAXVAL,    /* i64:maxval */
-    rt_fn_I64_MINVAL,    /* i64:minval */
+    rt_fn_I64_MAX,       /* i64:max */
+    rt_fn_I64_MIN,       /* i64:min */
 
-    rt_fn_F64_MAXVAL,    /* f64:maxval */
-    rt_fn_F64_MINVAL,    /* f64:minval */
+    rt_fn_F64_MAX,       /* f64:max */
+    rt_fn_F64_MIN,       /* f64:min */
 
     rt_fn_STR_EQUALS,    /* str:equals */
     rt_fn_STR_COMPARE,   /* str:compare */
+    rt_fn_STR_TOLOWER,   /* str:tolower */
+    rt_fn_STR_TOUPPER,   /* str:toupper */
     rt_fn_STR_APPEND,    /* str:append */
     rt_fn_STR_INSERT,    /* str:insert */
     rt_fn_STR_ERASE,     /* str:erase */
@@ -71,7 +81,8 @@ typedef enum {
     rt_fn_LST_JOIN,      /* lst:join */
     rt_fn_LST_SORT,      /* lst:sort */
 
-    rt_fn_MAP_INSERT,    /* map:insert */
+    rt_fn_MAP_SET,       /* map:set */
+    rt_fn_MAP_GET,       /* map:get */
     rt_fn_MAP_ERASE,     /* map:erase */
     rt_fn_MAP_CONCAT,    /* map:concat */
     rt_fn_MAP_FIND,      /* map:find */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -21,6 +21,7 @@ typedef enum {
     rt_fn_ISNULL,        /* isnull */
     rt_fn_TOSTR,         /* tostr */
     rt_fn_TYPE,          /* type */
+    rt_fn_CLONE,         /* clone */
 
     rt_fn_DBG_TYPENAME,  /* dbg:typename */
     rt_fn_DBG_RTSIZE,    /* dbg:rtsize */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -2,6 +2,7 @@
 #define RT_FUNCTIONS_H
 
 #include "runtime/data/Data.h"
+#include "runtime/functions/module_assert.h"
 #include "runtime/functions/module_chr.h"
 #include "runtime/functions/module_dbg.h"
 #include "runtime/functions/module_f64.h"
@@ -22,6 +23,10 @@ typedef enum {
     rt_fn_TOSTR,         /* tostr */
     rt_fn_TYPE,          /* type */
     rt_fn_CAST,          /* cast */
+
+    rt_fn_ASSERT_TYPE,   /* assert:type */
+    rt_fn_ASSERT_EQUALS, /* assert:equals */
+    rt_fn_ASSERT_NOTNULL,/* assert:notnull */
 
     rt_fn_DBG_TYPENAME,  /* dbg:typename */
     rt_fn_DBG_RTSIZE,    /* dbg:rtsize */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -38,6 +38,7 @@ typedef enum {
 
     rt_fn_IO_PRINT,      /* io:print */
     rt_fn_IO_INPUT,      /* io:input */
+    rt_fn_IO_FEXISTS,    /* io:exists */
     rt_fn_IO_FREAD,      /* io:fread */
     rt_fn_IO_FWRITE,     /* io:fwrite */
     rt_fn_IO_FAPPEND,    /* io:fappend */

--- a/include/runtime/functions/module_assert.h
+++ b/include/runtime/functions/module_assert.h
@@ -1,0 +1,10 @@
+#ifndef RT_FN_MODULE_ASSERT_H
+#define RT_FN_MODULE_ASSERT_H
+
+#include "runtime/data/Data.h"
+
+rt_Data_t rt_fn_assert_type();
+rt_Data_t rt_fn_assert_equals();
+rt_Data_t rt_fn_assert_notnull();
+
+#endif

--- a/include/runtime/functions/module_chr.h
+++ b/include/runtime/functions/module_chr.h
@@ -1,4 +1,15 @@
 #ifndef RT_FN_MODULE_CHR_H
 #define RT_FN_MODULE_CHR_H
 
+#include "runtime/data/Data.h"
+
+rt_Data_t rt_fn_chr_isdigit();
+rt_Data_t rt_fn_chr_isalpha();
+rt_Data_t rt_fn_chr_isalnum();
+rt_Data_t rt_fn_chr_islower();
+rt_Data_t rt_fn_chr_isupper();
+rt_Data_t rt_fn_chr_isspace();
+rt_Data_t rt_fn_chr_max();
+rt_Data_t rt_fn_chr_min();
+
 #endif

--- a/include/runtime/functions/module_dbg.h
+++ b/include/runtime/functions/module_dbg.h
@@ -4,8 +4,11 @@
 #include "runtime/data/Data.h"
 
 rt_Data_t rt_fn_dbg_typename();
+rt_Data_t rt_fn_dbg_rtsize();
 rt_Data_t rt_fn_dbg_refcnt();
 rt_Data_t rt_fn_dbg_id();
 rt_Data_t rt_fn_dbg_callproc();
+rt_Data_t rt_fn_dbg_filename();
+rt_Data_t rt_fn_dbg_lineno();
 
 #endif

--- a/include/runtime/functions/module_f64.h
+++ b/include/runtime/functions/module_f64.h
@@ -1,4 +1,9 @@
 #ifndef RT_FN_MODULE_F64_H
 #define RT_FN_MODULE_F64_H
 
+#include "runtime/data/Data.h"
+
+rt_Data_t rt_fn_f64_max();
+rt_Data_t rt_fn_f64_min();
+
 #endif

--- a/include/runtime/functions/module_i64.h
+++ b/include/runtime/functions/module_i64.h
@@ -1,4 +1,9 @@
 #ifndef RT_FN_MODULE_I64_H
 #define RT_FN_MODULE_I64_H
 
+#include "runtime/data/Data.h"
+
+rt_Data_t rt_fn_i64_max();
+rt_Data_t rt_fn_i64_min();
+
 #endif

--- a/include/runtime/functions/module_io.h
+++ b/include/runtime/functions/module_io.h
@@ -5,6 +5,7 @@
 
 rt_Data_t rt_fn_io_print();
 rt_Data_t rt_fn_io_input();
+rt_Data_t rt_fn_io_fexists();
 rt_Data_t rt_fn_io_fread();
 rt_Data_t rt_fn_io_fwrite();
 rt_Data_t rt_fn_io_fappend();

--- a/include/runtime/functions/module_io.h
+++ b/include/runtime/functions/module_io.h
@@ -5,5 +5,8 @@
 
 rt_Data_t rt_fn_io_print();
 rt_Data_t rt_fn_io_input();
+rt_Data_t rt_fn_io_fread();
+rt_Data_t rt_fn_io_fwrite();
+rt_Data_t rt_fn_io_fappend();
 
 #endif

--- a/include/runtime/functions/module_it.h
+++ b/include/runtime/functions/module_it.h
@@ -4,5 +4,6 @@
 #include "runtime/data/Data.h"
 
 rt_Data_t rt_fn_it_len();
+rt_Data_t rt_fn_it_clone();
 
 #endif

--- a/include/runtime/functions/module_map.h
+++ b/include/runtime/functions/module_map.h
@@ -1,4 +1,13 @@
 #ifndef RT_FN_MODULE_MAP_H
 #define RT_FN_MODULE_MAP_H
 
+#include "runtime/data/Data.h"
+
+rt_Data_t rt_fn_map_get();
+rt_Data_t rt_fn_map_set();
+rt_Data_t rt_fn_map_erase();
+rt_Data_t rt_fn_map_concat();
+rt_Data_t rt_fn_map_find();
+rt_Data_t rt_fn_map_keys();
+
 #endif

--- a/include/runtime/functions/module_str.h
+++ b/include/runtime/functions/module_str.h
@@ -5,6 +5,8 @@
 
 rt_Data_t rt_fn_str_equals();
 rt_Data_t rt_fn_str_compare();
+rt_Data_t rt_fn_str_tolower();
+rt_Data_t rt_fn_str_toupper();
 rt_Data_t rt_fn_str_append();
 rt_Data_t rt_fn_str_insert();
 rt_Data_t rt_fn_str_erase();

--- a/include/runtime/functions/nomodule.h
+++ b/include/runtime/functions/nomodule.h
@@ -6,6 +6,5 @@
 rt_Data_t rt_fn_isnull();
 rt_Data_t rt_fn_tostr();
 rt_Data_t rt_fn_type();
-rt_Data_t rt_fn_clone();
 
 #endif

--- a/include/runtime/functions/nomodule.h
+++ b/include/runtime/functions/nomodule.h
@@ -6,5 +6,6 @@
 rt_Data_t rt_fn_isnull();
 rt_Data_t rt_fn_tostr();
 rt_Data_t rt_fn_type();
+rt_Data_t rt_fn_cast();
 
 #endif

--- a/include/runtime/functions/nomodule.h
+++ b/include/runtime/functions/nomodule.h
@@ -6,5 +6,6 @@
 rt_Data_t rt_fn_isnull();
 rt_Data_t rt_fn_tostr();
 rt_Data_t rt_fn_type();
+rt_Data_t rt_fn_clone();
 
 #endif

--- a/src/io.c
+++ b/src/io.c
@@ -1,8 +1,10 @@
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include "errcodes.h"
 #include "globals.h"
@@ -11,22 +13,14 @@
 #ifndef IO_GETLINE
 #define IO_GETLINE
 
-/* The original code is public domain -- Will Hartung 4/9/09 */
-/* Modifications, public domain as well, by Antti Haapala, 11/10/17
-   - Switched to getc on 5/23/19 */
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <stdint.h>
-
-// if typedef doesn't exist (msvc, blah)
-typedef intptr_t ssize_t;
-
 /** read string contains trailing new line.
     size_t n is the number of bytes allocated.
     return value is the length of string read. */
-ssize_t io_getline(char **lineptr, size_t *n, FILE *stream) {
+ssize_t io_getline(char **lineptr, size_t *n, FILE *stream)
+{
+    /* The original code is public domain -- Will Hartung 4/9/09 */
+    /* Modifications, public domain as well, by Antti Haapala, 11/10/17
+       - Switched to getc on 5/23/19 */
     size_t pos;
     int c;
 

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -32,18 +32,18 @@ rt_VarTable_Acc_t rt_vtable_accumulator = {
 
 
 /* few globally defined variables */
-rt_Data_t rt_VarTable_rsv_lf      = { .data.chr = '\n',             .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false },
+rt_Data_t rt_VarTable_rsv_lf      = { .data.chr = '\n',             .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false, .lvalue = false },
 /* list of globally defined typename variables */
-          rt_VarTable_typeid_bul  = { .data.i64 = rt_DATA_TYPE_BUL, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_chr  = { .data.i64 = rt_DATA_TYPE_CHR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_i64  = { .data.i64 = rt_DATA_TYPE_I64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_f64  = { .data.i64 = rt_DATA_TYPE_F64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_str  = { .data.i64 = rt_DATA_TYPE_STR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_lst  = { .data.i64 = rt_DATA_TYPE_LST, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_any  = { .data.i64 = rt_DATA_TYPE_ANY, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_map  = { .data.i64 = rt_DATA_TYPE_MAP, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_proc = { .data.i64 = rt_DATA_TYPE_PROC,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_rsv_null    = { .data.any = NULL,             .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false };
+          rt_VarTable_typeid_bul  = { .data.i64 = rt_DATA_TYPE_BUL, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_chr  = { .data.i64 = rt_DATA_TYPE_CHR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_i64  = { .data.i64 = rt_DATA_TYPE_I64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_f64  = { .data.i64 = rt_DATA_TYPE_F64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_str  = { .data.i64 = rt_DATA_TYPE_STR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_lst  = { .data.i64 = rt_DATA_TYPE_LST, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_any  = { .data.i64 = rt_DATA_TYPE_ANY, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_map  = { .data.i64 = rt_DATA_TYPE_MAP, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_typeid_proc = { .data.i64 = rt_DATA_TYPE_PROC,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_rsv_null    = { .data.any = NULL,             .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false, .lvalue = false };
 
 
 rt_Data_t *rt_VarTable_get_globvar(const char *varname)
@@ -79,6 +79,7 @@ void rt_VarTable_create(const char *varname, rt_Data_t value, bool is_const, boo
         io_errndie("rt_VarTable_create:" ERR_MSG_NULLPTR);
     /* if data is const throw error */
     if (data->is_const) rt_throw("cannot modify const variable");
+    data->lvalue = true;
     rt_VarTable_modf(data, value, is_const, is_weak);
 }
 
@@ -98,6 +99,10 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src, bool is_const, bool 
         if (dest == &rt_VarTable_typeid_map) rt_throw("cannot modify reserved variable 'map'");
         if (dest == &rt_VarTable_rsv_null)   rt_throw("cannot modify reserved variable 'null'");
     }
+
+    /* if dest is not lvalue, throw error */
+    if (!dest->lvalue) rt_throw("lhs of assignment is not an lvalue");
+
     /* if data is const, throw appropriate error */
     if (dest->is_const) rt_throw("cannot modify const variable");
 
@@ -113,7 +118,8 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src, bool is_const, bool 
         .data = src.data,
         .type = src.type,
         .is_const = is_const,
-        .is_weak = is_weak
+        .is_weak = is_weak,
+        .lvalue = false
     };
     return dest;
 }
@@ -164,6 +170,7 @@ void rt_VarTable_acc_setval(rt_Data_t val)
         .data = val.data,
         .is_const = false,
         .is_weak = false,
+        .lvalue = false
     };
     rt_vtable_accumulator.adr = NULL;
 }
@@ -176,6 +183,7 @@ void rt_VarTable_acc_setadr(rt_Data_t *adr)
     else rt_Data_decrefc(rt_vtable_accumulator.adr);
     rt_vtable_accumulator.val = rt_Data_null();
     rt_vtable_accumulator.adr = adr;
+    rt_vtable_accumulator.adr->lvalue = true;
 }
 
 

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -89,15 +89,16 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src, bool is_const, bool 
     if (!dest) return NULL;
     /* if data is one of the global built-in vars, throw appropriate error */
     {
-        if (dest == &rt_VarTable_rsv_lf)     rt_throw("cannot modify reserved variable 'lf'");
-        if (dest == &rt_VarTable_typeid_bul) rt_throw("cannot modify reserved variable 'bul'");
-        if (dest == &rt_VarTable_typeid_chr) rt_throw("cannot modify reserved variable 'chr'");
-        if (dest == &rt_VarTable_typeid_i64) rt_throw("cannot modify reserved variable 'i64'");
-        if (dest == &rt_VarTable_typeid_f64) rt_throw("cannot modify reserved variable 'f64'");
-        if (dest == &rt_VarTable_typeid_str) rt_throw("cannot modify reserved variable 'str'");
-        if (dest == &rt_VarTable_typeid_lst) rt_throw("cannot modify reserved variable 'lst'");
-        if (dest == &rt_VarTable_typeid_map) rt_throw("cannot modify reserved variable 'map'");
-        if (dest == &rt_VarTable_rsv_null)   rt_throw("cannot modify reserved variable 'null'");
+        if (dest == &rt_VarTable_rsv_lf)      rt_throw("cannot modify reserved variable 'lf'");
+        if (dest == &rt_VarTable_typeid_bul)  rt_throw("cannot modify reserved variable 'bul'");
+        if (dest == &rt_VarTable_typeid_chr)  rt_throw("cannot modify reserved variable 'chr'");
+        if (dest == &rt_VarTable_typeid_i64)  rt_throw("cannot modify reserved variable 'i64'");
+        if (dest == &rt_VarTable_typeid_f64)  rt_throw("cannot modify reserved variable 'f64'");
+        if (dest == &rt_VarTable_typeid_str)  rt_throw("cannot modify reserved variable 'str'");
+        if (dest == &rt_VarTable_typeid_lst)  rt_throw("cannot modify reserved variable 'lst'");
+        if (dest == &rt_VarTable_typeid_map)  rt_throw("cannot modify reserved variable 'map'");
+        if (dest == &rt_VarTable_typeid_proc) rt_throw("cannot modify reserved variable 'proc'");
+        if (dest == &rt_VarTable_rsv_null)    rt_throw("cannot modify reserved variable 'null'");
     }
 
     /* if dest is not lvalue, throw error */

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -32,17 +32,18 @@ rt_VarTable_Acc_t rt_vtable_accumulator = {
 
 
 /* few globally defined variables */
-rt_Data_t rt_VarTable_rsv_lf     = { .data.chr = '\n',            .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false },
+rt_Data_t rt_VarTable_rsv_lf      = { .data.chr = '\n',             .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false },
 /* list of globally defined typename variables */
-          rt_VarTable_typeid_bul = { .data.i64 = rt_DATA_TYPE_BUL,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_chr = { .data.i64 = rt_DATA_TYPE_CHR,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_i64 = { .data.i64 = rt_DATA_TYPE_I64,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_f64 = { .data.i64 = rt_DATA_TYPE_F64,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_str = { .data.i64 = rt_DATA_TYPE_STR,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_lst = { .data.i64 = rt_DATA_TYPE_LST,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_any = { .data.i64 = rt_DATA_TYPE_ANY,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_typeid_map = { .data.i64 = rt_DATA_TYPE_MAP,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
-          rt_VarTable_rsv_null   = { .data.any = NULL,            .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false };
+          rt_VarTable_typeid_bul  = { .data.i64 = rt_DATA_TYPE_BUL, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_chr  = { .data.i64 = rt_DATA_TYPE_CHR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_i64  = { .data.i64 = rt_DATA_TYPE_I64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_f64  = { .data.i64 = rt_DATA_TYPE_F64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_str  = { .data.i64 = rt_DATA_TYPE_STR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_lst  = { .data.i64 = rt_DATA_TYPE_LST, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_any  = { .data.i64 = rt_DATA_TYPE_ANY, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_map  = { .data.i64 = rt_DATA_TYPE_MAP, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_typeid_proc = { .data.i64 = rt_DATA_TYPE_PROC,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false },
+          rt_VarTable_rsv_null    = { .data.any = NULL,             .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false };
 
 
 rt_Data_t *rt_VarTable_get_globvar(const char *varname)
@@ -55,6 +56,7 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
     if (!strcmp("str", varname))  return &rt_VarTable_typeid_str;
     if (!strcmp("lst", varname))  return &rt_VarTable_typeid_lst;
     if (!strcmp("map", varname))  return &rt_VarTable_typeid_map;
+    if (!strcmp("proc", varname)) return &rt_VarTable_typeid_proc;
     if (!strcmp("null", varname)) return &rt_VarTable_rsv_null;
     return NULL;
 }

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -576,6 +576,95 @@ char *rt_Data_tostr(const rt_Data_t var)
     return NULL;
 }
 
+rt_Data_t rt_Data_cast(const rt_Data_t data, enum rt_DataType_t type)
+{
+    if (data.type == type)
+        return rt_Data_clone(data);
+    switch (type) {
+        case rt_DATA_TYPE_BUL:
+            return rt_Data_bul(rt_Data_tobool(data));
+        case rt_DATA_TYPE_CHR: {
+            switch (data.type) {
+                case rt_DATA_TYPE_BUL:
+                    return rt_Data_chr((char) data.data.bul);
+                case rt_DATA_TYPE_CHR:
+                    return rt_Data_chr((char) data.data.chr);
+                case rt_DATA_TYPE_I64:
+                    return rt_Data_chr((char) data.data.i64);
+                case rt_DATA_TYPE_F64:
+                    return rt_Data_chr((char) data.data.f64);
+                case rt_DATA_TYPE_STR:
+                case rt_DATA_TYPE_LST:
+                case rt_DATA_TYPE_MAP:
+                case rt_DATA_TYPE_INTERP_STR:
+                case rt_DATA_TYPE_PROC:
+                case rt_DATA_TYPE_ANY:
+                    rt_throw("cannot cast %s to 'chr'", rt_Data_typename(data));
+            }
+        }
+        case rt_DATA_TYPE_I64: {
+            switch (data.type) {
+                case rt_DATA_TYPE_BUL:
+                    return rt_Data_i64((int64_t) data.data.bul);
+                case rt_DATA_TYPE_CHR:
+                    return rt_Data_i64((int64_t) data.data.chr);
+                case rt_DATA_TYPE_I64:
+                    return rt_Data_i64((int64_t) data.data.i64);
+                case rt_DATA_TYPE_F64:
+                    return rt_Data_i64((int64_t) data.data.f64);
+                case rt_DATA_TYPE_STR:
+                case rt_DATA_TYPE_LST:
+                case rt_DATA_TYPE_MAP:
+                case rt_DATA_TYPE_INTERP_STR:
+                case rt_DATA_TYPE_PROC:
+                case rt_DATA_TYPE_ANY:
+                    rt_throw("cannot cast %s to 'i64'", rt_Data_typename(data));
+            }
+        }
+        case rt_DATA_TYPE_F64: {
+            switch (data.type) {
+                case rt_DATA_TYPE_BUL:
+                    return rt_Data_f64((double) data.data.bul);
+                case rt_DATA_TYPE_CHR:
+                    return rt_Data_f64((double) data.data.chr);
+                case rt_DATA_TYPE_I64:
+                    return rt_Data_f64((double) data.data.i64);
+                case rt_DATA_TYPE_F64:
+                    return rt_Data_f64((double) data.data.f64);
+                case rt_DATA_TYPE_STR:
+                case rt_DATA_TYPE_LST:
+                case rt_DATA_TYPE_MAP:
+                case rt_DATA_TYPE_INTERP_STR:
+                case rt_DATA_TYPE_PROC:
+                case rt_DATA_TYPE_ANY:
+                    rt_throw("cannot cast %s to 'f64'", rt_Data_typename(data));
+            }
+        }
+        case rt_DATA_TYPE_STR: {
+            char *strdata = rt_Data_tostr(data);
+            rt_Data_t retstr = rt_Data_str(rt_DataStr_init(strdata));
+            free(strdata);
+            return retstr;
+        }
+        case rt_DATA_TYPE_LST:
+            rt_throw("cannot cast %s to 'lst'", rt_Data_typename(data));
+            break;
+        case rt_DATA_TYPE_MAP:
+            rt_throw("cannot cast %s to 'map'", rt_Data_typename(data));
+            break;
+        case rt_DATA_TYPE_INTERP_STR:
+            rt_throw("cannot cast %s to 'interp_str'", rt_Data_typename(data));
+            break;
+        case rt_DATA_TYPE_PROC:
+            rt_throw("cannot cast %s to 'proc'", rt_Data_typename(data));
+            break;
+        case rt_DATA_TYPE_ANY:
+            rt_throw("cannot cast %s to 'any'", rt_Data_typename(data));
+            break;
+    }
+    return rt_Data_null();
+}
+
 const char *rt_Data_typename(const rt_Data_t var)
 {
     switch (var.type) {

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -24,6 +24,7 @@ rt_Data_t rt_Data_bul(bool val)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_BUL;
     var.data.bul = !!val;
     return var;
@@ -34,6 +35,7 @@ rt_Data_t rt_Data_chr(char val)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_CHR;
     var.data.chr = val;
     return var;
@@ -44,6 +46,7 @@ rt_Data_t rt_Data_i64(int64_t val)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_I64;
     var.data.i64 = val;
     return var;
@@ -54,6 +57,7 @@ rt_Data_t rt_Data_f64(double val)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_F64;
     var.data.f64 = val;
     return var;
@@ -69,6 +73,7 @@ rt_Data_t rt_Data_str(rt_DataStr_t *str)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_STR;
     var.data.str = str;
     return var;
@@ -88,6 +93,7 @@ rt_Data_t rt_Data_list(rt_DataList_t *lst)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_LST;
     var.data.lst = lst;
     return var;
@@ -98,6 +104,7 @@ rt_Data_t rt_Data_map(rt_DataMap_t *mp)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_MAP;
     var.data.mp = mp;
     return var;
@@ -110,6 +117,7 @@ rt_Data_t rt_Data_proc(
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_PROC;
     var.data.proc.module_name = module_name;
     var.data.proc.proc_name = proc_name;
@@ -122,6 +130,7 @@ rt_Data_t rt_Data_any(void *ptr)
     rt_Data_t var;
     var.is_const = false;
     var.is_weak = false;
+    var.lvalue = false;
     var.type = rt_DATA_TYPE_ANY;
     var.data.any = ptr;
     return var;

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -178,6 +178,35 @@ void rt_Data_decrefc(rt_Data_t *var)
     }
 }
 
+rt_Data_t rt_Data_clone(const rt_Data_t var)
+{
+    switch (var.type) {
+        case rt_DATA_TYPE_BUL:
+            return rt_Data_bul(var.data.bul);
+        case rt_DATA_TYPE_CHR:
+            return rt_Data_chr(var.data.chr);
+        case rt_DATA_TYPE_I64:
+            return rt_Data_i64(var.data.i64);
+        case rt_DATA_TYPE_F64:
+            return rt_Data_f64(var.data.f64);
+        case rt_DATA_TYPE_STR:
+        case rt_DATA_TYPE_INTERP_STR:
+            return rt_Data_str(rt_DataStr_clone(var.data.str));
+        case rt_DATA_TYPE_LST:
+            return rt_Data_list(rt_DataList_clone(var.data.lst));
+        case rt_DATA_TYPE_MAP:
+            return rt_Data_map(rt_DataMap_clone(var.data.mp));
+        case rt_DATA_TYPE_ANY:
+            return rt_Data_any(var.data.any);
+        case rt_DATA_TYPE_PROC:
+            return rt_Data_proc(
+                var.data.proc.module_name,
+                var.data.proc.proc_name
+            );
+    }
+    return rt_Data_null();
+}
+
 void rt_Data_destroy_circular(rt_Data_t *var, bool flag)
 {
     /* if ref is weak, don't free it */

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -28,6 +28,22 @@ rt_DataMap_t *rt_DataMap_init()
     return mp;
 }
 
+rt_DataMap_t *rt_DataMap_clone(const rt_DataMap_t *mp)
+{
+    rt_DataMap_t *mp_copy = rt_DataMap_init();
+    for (
+        rt_DataMap_iter_t entry_it = rt_DataMap_begin((rt_DataMap_t*) mp);
+        entry_it != rt_DataMap_end((rt_DataMap_t*) mp);
+        ++entry_it
+    ) {
+        if (!rt_DataMap_exists((rt_DataMap_t*) mp, entry_it)) continue;
+        const char *key = rt_DataMap_get((rt_DataMap_t*) mp, entry_it)->key;
+        rt_Data_t value = rt_DataMap_get((rt_DataMap_t*) mp, entry_it)->value;
+        rt_DataMap_insert(mp_copy, key, value);
+    }
+    return mp_copy;
+}
+
 int64_t rt_DataMap_length(const rt_DataMap_t *mp)
 {
     return mp->length;

--- a/src/runtime/data/DataStr.c.h
+++ b/src/runtime/data/DataStr.c.h
@@ -63,6 +63,28 @@ void rt_DataStr_destroy(rt_DataStr_t **ptr)
     rt_DataStr_destroy_circular(ptr, false);
 }
 
+void rt_DataStr_toupper(rt_DataStr_t *str)
+{
+    int64_t length = rt_DataStr_length(str);
+    for (int64_t i = 0; i < length; i++) {
+        char c = rt_DataList_getref(str->var, i)->data.chr;
+        if (c >= 'a' && c <= 'z') {
+            rt_DataList_getref(str->var, i)->data.chr = c - 32;
+        }
+    }
+}
+
+void rt_DataStr_tolower(rt_DataStr_t *str)
+{
+    int64_t length = rt_DataStr_length(str);
+    for (int64_t i = 0; i < length; i++) {
+        char c = rt_DataList_getref(str->var, i)->data.chr;
+        if (c >= 'A' && c <= 'Z') {
+            rt_DataList_getref(str->var, i)->data.chr = c + 32;
+        }
+    }
+}
+
 void rt_DataStr_append(rt_DataStr_t *str, char var)
 {
     rt_DataList_append(str->var, rt_Data_chr(var));

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -136,7 +136,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_IO_FAPPEND:    return rt_fn_io_fappend();
 
         case rt_fn_IT_LEN:        return rt_fn_it_len();
-#if 0
+
         case rt_fn_CHR_ISDIGIT:   return rt_fn_chr_isdigit();
         case rt_fn_CHR_ISALPHA:   return rt_fn_chr_isalpha();
         case rt_fn_CHR_ISALNUM:   return rt_fn_chr_isalnum();
@@ -145,7 +145,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_CHR_ISSPACE:   return rt_fn_chr_isspace();
         case rt_fn_CHR_MAX:       return rt_fn_chr_max();
         case rt_fn_CHR_MIN:       return rt_fn_chr_min();
-#endif
+
         case rt_fn_I64_MAX:       return rt_fn_i64_max();
         case rt_fn_I64_MIN:       return rt_fn_i64_min();
 
@@ -179,14 +179,14 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_LST_FIND:      return rt_fn_lst_find();
         case rt_fn_LST_JOIN:      return rt_fn_lst_join();
         case rt_fn_LST_SORT:      return rt_fn_lst_sort();
-#if 0
+
         case rt_fn_MAP_SET:       return rt_fn_map_set();
         case rt_fn_MAP_GET:       return rt_fn_map_get();
         case rt_fn_MAP_ERASE:     return rt_fn_map_erase();
         case rt_fn_MAP_CONCAT:    return rt_fn_map_concat();
         case rt_fn_MAP_FIND:      return rt_fn_map_find();
         case rt_fn_MAP_KEYS:      return rt_fn_map_keys();
-#endif
+
         case rt_fn_UNDEFINED:
             break;
     }

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -14,6 +14,11 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     /* if module matched but procedure didn't match, it should cascade down.
        this is done so that if all matches fail, you can still match the procedures
        that don't have a module name */
+    if (!strcmp(module, "assert")) {
+        if (!strcmp(fname, "type"))     return rt_fn_ASSERT_TYPE;
+        if (!strcmp(fname, "equals"))   return rt_fn_ASSERT_EQUALS;
+        if (!strcmp(fname, "notnull"))  return rt_fn_ASSERT_NOTNULL;
+    }
     if (!strcmp(module, "dbg")) {
         if (!strcmp(fname, "typename")) return rt_fn_DBG_TYPENAME;
         if (!strcmp(fname, "rtsize"))   return rt_fn_DBG_RTSIZE;
@@ -100,6 +105,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     return rt_fn_UNDEFINED;
 }
 
+#include "runtime/functions/module_assert.c.h"
 #include "runtime/functions/module_chr.c.h"
 #include "runtime/functions/module_dbg.c.h"
 #include "runtime/functions/module_f64.c.h"
@@ -118,6 +124,10 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_TOSTR:         return rt_fn_tostr();
         case rt_fn_TYPE:          return rt_fn_type();
         case rt_fn_CAST:          return rt_fn_cast();
+
+        case rt_fn_ASSERT_TYPE:   return rt_fn_assert_type();
+        case rt_fn_ASSERT_EQUALS: return rt_fn_assert_equals();
+        case rt_fn_ASSERT_NOTNULL:return rt_fn_assert_notnull();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
 #if 0

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -31,6 +31,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     if (!strcmp(module, "io")) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;
         if (!strcmp(fname, "input"))    return rt_fn_IO_INPUT;
+        if (!strcmp(fname, "fexists"))  return rt_fn_IO_FEXISTS;
         if (!strcmp(fname, "fread"))    return rt_fn_IO_FREAD;
         if (!strcmp(fname, "fwrite"))   return rt_fn_IO_FWRITE;
         if (!strcmp(fname, "fappend"))  return rt_fn_IO_FAPPEND;
@@ -141,6 +142,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
 
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();
+        case rt_fn_IO_FEXISTS:    return rt_fn_io_fexists();
         case rt_fn_IO_FREAD:      return rt_fn_io_fread();
         case rt_fn_IO_FWRITE:     return rt_fn_io_fwrite();
         case rt_fn_IO_FAPPEND:    return rt_fn_io_fappend();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -95,6 +95,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
     if (!strcmp(fname, "tostr"))        return rt_fn_TOSTR;
     if (!strcmp(fname, "type"))         return rt_fn_TYPE;
+    if (!strcmp(fname, "cast"))         return rt_fn_CAST;
 
     return rt_fn_UNDEFINED;
 }
@@ -116,6 +117,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_ISNULL:        return rt_fn_isnull();
         case rt_fn_TOSTR:         return rt_fn_tostr();
         case rt_fn_TYPE:          return rt_fn_type();
+        case rt_fn_CAST:          return rt_fn_cast();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
 #if 0

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -16,20 +16,46 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
        that don't have a module name */
     if (!strcmp(module, "dbg")) {
         if (!strcmp(fname, "typename")) return rt_fn_DBG_TYPENAME;
+        if (!strcmp(fname, "rtsize"))   return rt_fn_DBG_RTSIZE;
         if (!strcmp(fname, "refcnt"))   return rt_fn_DBG_REFCNT;
         if (!strcmp(fname, "id"))       return rt_fn_DBG_ID;
         if (!strcmp(fname, "callproc")) return rt_fn_DBG_CALLPROC;
+        if (!strcmp(fname, "filename")) return rt_fn_DBG_FILENAME;
+        if (!strcmp(fname, "lineno"))   return rt_fn_DBG_LINENO;
     }
     if (!strcmp(module, "io")) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;
         if (!strcmp(fname, "input"))    return rt_fn_IO_INPUT;
+        if (!strcmp(fname, "fread"))    return rt_fn_IO_FREAD;
+        if (!strcmp(fname, "fwrite"))   return rt_fn_IO_FWRITE;
+        if (!strcmp(fname, "fappend"))  return rt_fn_IO_FAPPEND;
     }
     if (!strcmp(module, "it")) {
         if (!strcmp(fname, "len"))      return rt_fn_IT_LEN;
     }
+    if (!strcmp(module, "chr")) {
+        if (!strcmp(fname, "isdigit"))  return rt_fn_CHR_ISDIGIT;
+        if (!strcmp(fname, "isalpha"))  return rt_fn_CHR_ISALPHA;
+        if (!strcmp(fname, "isalnum"))  return rt_fn_CHR_ISALNUM;
+        if (!strcmp(fname, "islower"))  return rt_fn_CHR_ISLOWER;
+        if (!strcmp(fname, "isupper"))  return rt_fn_CHR_ISUPPER;
+        if (!strcmp(fname, "isspace"))  return rt_fn_CHR_ISSPACE;
+        if (!strcmp(fname, "max"))      return rt_fn_CHR_MAX;
+        if (!strcmp(fname, "min"))      return rt_fn_CHR_MIN;
+    }
+    if (!strcmp(module, "i64")) {
+        if (!strcmp(fname, "max"))      return rt_fn_I64_MAX;
+        if (!strcmp(fname, "min"))      return rt_fn_I64_MIN;
+    }
+    if (!strcmp(module, "f64")) {
+        if (!strcmp(fname, "max"))      return rt_fn_F64_MAX;
+        if (!strcmp(fname, "min"))      return rt_fn_F64_MIN;
+    }
     if (!strcmp(module, "str")) {
         if (!strcmp(fname, "equals"))   return rt_fn_STR_EQUALS;
         if (!strcmp(fname, "compare"))  return rt_fn_STR_COMPARE;
+        if (!strcmp(fname, "tolower"))  return rt_fn_STR_TOLOWER;
+        if (!strcmp(fname, "toupper"))  return rt_fn_STR_TOUPPER;
         if (!strcmp(fname, "append"))   return rt_fn_STR_APPEND;
         if (!strcmp(fname, "insert"))   return rt_fn_STR_INSERT;
         if (!strcmp(fname, "erase"))    return rt_fn_STR_ERASE;
@@ -54,6 +80,15 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "sublist"))  return rt_fn_LST_SUBLIST;
         if (!strcmp(fname, "join"))     return rt_fn_LST_JOIN;
         if (!strcmp(fname, "sort"))     return rt_fn_LST_SORT;
+    }
+
+    if (!strcmp(module, "map")) {
+        if (!strcmp(fname, "set"))      return rt_fn_MAP_SET;
+        if (!strcmp(fname, "get"))      return rt_fn_MAP_GET;
+        if (!strcmp(fname, "erase"))    return rt_fn_MAP_ERASE;
+        if (!strcmp(fname, "concat"))   return rt_fn_MAP_CONCAT;
+        if (!strcmp(fname, "find"))     return rt_fn_MAP_FIND;
+        if (!strcmp(fname, "keys"))     return rt_fn_MAP_KEYS;
     }
 
     if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
@@ -82,17 +117,40 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_TYPE:          return rt_fn_type();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
+        case rt_fn_DBG_RTSIZE:    return rt_fn_dbg_rtsize();
         case rt_fn_DBG_REFCNT:    return rt_fn_dbg_refcnt();
         case rt_fn_DBG_ID:        return rt_fn_dbg_id();
         case rt_fn_DBG_CALLPROC:  return rt_fn_dbg_callproc();
+        case rt_fn_DBG_FILENAME:  return rt_fn_dbg_filename();
+        case rt_fn_DBG_LINENO:    return rt_fn_dbg_lineno();
 
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();
+        case rt_fn_IO_FREAD:      return rt_fn_io_fread();
+        case rt_fn_IO_FWRITE:     return rt_fn_io_fwrite();
+        case rt_fn_IO_FAPPEND:    return rt_fn_io_fappend();
 
         case rt_fn_IT_LEN:        return rt_fn_it_len();
 
+        case rt_fn_CHR_ISDIGIT:   return rt_fn_chr_isdigit();
+        case rt_fn_CHR_ISALPHA:   return rt_fn_chr_isalpha();
+        case rt_fn_CHR_ISALNUM:   return rt_fn_chr_isalnum();
+        case rt_fn_CHR_ISLOWER:   return rt_fn_chr_islower();
+        case rt_fn_CHR_ISUPPER:   return rt_fn_chr_isupper();
+        case rt_fn_CHR_ISSPACE:   return rt_fn_chr_isspace();
+        case rt_fn_CHR_MAX:       return rt_fn_chr_max();
+        case rt_fn_CHR_MIN:       return rt_fn_chr_min();
+
+        case rt_fn_I64_MAX:       return rt_fn_i64_max();
+        case rt_fn_I64_MIN:       return rt_fn_i64_min();
+
+        case rt_fn_F64_MAX:       return rt_fn_f64_max();
+        case rt_fn_F64_MIN:       return rt_fn_f64_min();
+
         case rt_fn_STR_EQUALS:    return rt_fn_str_equals();
         case rt_fn_STR_COMPARE:   return rt_fn_str_compare();
+        case rt_fn_STR_TOLOWER:   return rt_fn_str_tolower();
+        case rt_fn_STR_TOUPPER:   return rt_fn_str_toupper();
         case rt_fn_STR_APPEND:    return rt_fn_str_append();
         case rt_fn_STR_INSERT:    return rt_fn_str_insert();
         case rt_fn_STR_ERASE:     return rt_fn_str_erase();
@@ -117,10 +175,18 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_LST_JOIN:      return rt_fn_lst_join();
         case rt_fn_LST_SORT:      return rt_fn_lst_sort();
 
+        case rt_fn_MAP_SET:       return rt_fn_map_set();
+        case rt_fn_MAP_GET:       return rt_fn_map_get();
+        case rt_fn_MAP_ERASE:     return rt_fn_map_erase();
+        case rt_fn_MAP_CONCAT:    return rt_fn_map_concat();
+        case rt_fn_MAP_FIND:      return rt_fn_map_find();
+        case rt_fn_MAP_KEYS:      return rt_fn_map_keys();
+
         case rt_fn_UNDEFINED:
-            io_errndie("rt_fn_FunctionsList_call: undefined procedure for desc: '%d'", fn);
             break;
     }
+
+    io_errndie("rt_fn_FunctionsList_call: undefined procedure for desc: '%d'", fn);
     return rt_Data_null();
 }
 

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -124,10 +124,9 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_DBG_REFCNT:    return rt_fn_dbg_refcnt();
         case rt_fn_DBG_ID:        return rt_fn_dbg_id();
         case rt_fn_DBG_CALLPROC:  return rt_fn_dbg_callproc();
-#if 0
         case rt_fn_DBG_FILENAME:  return rt_fn_dbg_filename();
         case rt_fn_DBG_LINENO:    return rt_fn_dbg_lineno();
-#endif
+
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();
         case rt_fn_IO_FREAD:      return rt_fn_io_fread();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -154,10 +154,8 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
 
         case rt_fn_STR_EQUALS:    return rt_fn_str_equals();
         case rt_fn_STR_COMPARE:   return rt_fn_str_compare();
-#if 0
         case rt_fn_STR_TOLOWER:   return rt_fn_str_tolower();
         case rt_fn_STR_TOUPPER:   return rt_fn_str_toupper();
-#endif
         case rt_fn_STR_APPEND:    return rt_fn_str_append();
         case rt_fn_STR_INSERT:    return rt_fn_str_insert();
         case rt_fn_STR_ERASE:     return rt_fn_str_erase();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -94,6 +94,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
     if (!strcmp(fname, "tostr"))        return rt_fn_TOSTR;
     if (!strcmp(fname, "type"))         return rt_fn_TYPE;
+    if (!strcmp(fname, "clone"))        return rt_fn_CLONE;
 
     return rt_fn_UNDEFINED;
 }
@@ -115,6 +116,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_ISNULL:        return rt_fn_isnull();
         case rt_fn_TOSTR:         return rt_fn_tostr();
         case rt_fn_TYPE:          return rt_fn_type();
+        case rt_fn_CLONE:         return rt_fn_clone();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
 #if 0

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -198,6 +198,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_MAP_FIND:      return rt_fn_map_find();
         case rt_fn_MAP_KEYS:      return rt_fn_map_keys();
 
+        case rt_fn_DBG_RTSIZE:
         case rt_fn_UNDEFINED:
             break;
     }

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -32,6 +32,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     }
     if (!strcmp(module, "it")) {
         if (!strcmp(fname, "len"))      return rt_fn_IT_LEN;
+        if (!strcmp(fname, "clone"))    return rt_fn_IT_CLONE;
     }
     if (!strcmp(module, "chr")) {
         if (!strcmp(fname, "isdigit"))  return rt_fn_CHR_ISDIGIT;
@@ -94,7 +95,6 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
     if (!strcmp(fname, "tostr"))        return rt_fn_TOSTR;
     if (!strcmp(fname, "type"))         return rt_fn_TYPE;
-    if (!strcmp(fname, "clone"))        return rt_fn_CLONE;
 
     return rt_fn_UNDEFINED;
 }
@@ -116,7 +116,6 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_ISNULL:        return rt_fn_isnull();
         case rt_fn_TOSTR:         return rt_fn_tostr();
         case rt_fn_TYPE:          return rt_fn_type();
-        case rt_fn_CLONE:         return rt_fn_clone();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
 #if 0
@@ -136,6 +135,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_IO_FAPPEND:    return rt_fn_io_fappend();
 
         case rt_fn_IT_LEN:        return rt_fn_it_len();
+        case rt_fn_IT_CLONE:      return rt_fn_it_clone();
 
         case rt_fn_CHR_ISDIGIT:   return rt_fn_chr_isdigit();
         case rt_fn_CHR_ISALPHA:   return rt_fn_chr_isalpha();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -117,13 +117,16 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_TYPE:          return rt_fn_type();
 
         case rt_fn_DBG_TYPENAME:  return rt_fn_dbg_typename();
+#if 0
         case rt_fn_DBG_RTSIZE:    return rt_fn_dbg_rtsize();
+#endif
         case rt_fn_DBG_REFCNT:    return rt_fn_dbg_refcnt();
         case rt_fn_DBG_ID:        return rt_fn_dbg_id();
         case rt_fn_DBG_CALLPROC:  return rt_fn_dbg_callproc();
+#if 0
         case rt_fn_DBG_FILENAME:  return rt_fn_dbg_filename();
         case rt_fn_DBG_LINENO:    return rt_fn_dbg_lineno();
-
+#endif
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();
         case rt_fn_IO_FREAD:      return rt_fn_io_fread();
@@ -131,7 +134,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_IO_FAPPEND:    return rt_fn_io_fappend();
 
         case rt_fn_IT_LEN:        return rt_fn_it_len();
-
+#if 0
         case rt_fn_CHR_ISDIGIT:   return rt_fn_chr_isdigit();
         case rt_fn_CHR_ISALPHA:   return rt_fn_chr_isalpha();
         case rt_fn_CHR_ISALNUM:   return rt_fn_chr_isalnum();
@@ -140,7 +143,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_CHR_ISSPACE:   return rt_fn_chr_isspace();
         case rt_fn_CHR_MAX:       return rt_fn_chr_max();
         case rt_fn_CHR_MIN:       return rt_fn_chr_min();
-
+#endif
         case rt_fn_I64_MAX:       return rt_fn_i64_max();
         case rt_fn_I64_MIN:       return rt_fn_i64_min();
 
@@ -149,8 +152,10 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
 
         case rt_fn_STR_EQUALS:    return rt_fn_str_equals();
         case rt_fn_STR_COMPARE:   return rt_fn_str_compare();
+#if 0
         case rt_fn_STR_TOLOWER:   return rt_fn_str_tolower();
         case rt_fn_STR_TOUPPER:   return rt_fn_str_toupper();
+#endif
         case rt_fn_STR_APPEND:    return rt_fn_str_append();
         case rt_fn_STR_INSERT:    return rt_fn_str_insert();
         case rt_fn_STR_ERASE:     return rt_fn_str_erase();
@@ -174,14 +179,14 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_LST_FIND:      return rt_fn_lst_find();
         case rt_fn_LST_JOIN:      return rt_fn_lst_join();
         case rt_fn_LST_SORT:      return rt_fn_lst_sort();
-
+#if 0
         case rt_fn_MAP_SET:       return rt_fn_map_set();
         case rt_fn_MAP_GET:       return rt_fn_map_get();
         case rt_fn_MAP_ERASE:     return rt_fn_map_erase();
         case rt_fn_MAP_CONCAT:    return rt_fn_map_concat();
         case rt_fn_MAP_FIND:      return rt_fn_map_find();
         case rt_fn_MAP_KEYS:      return rt_fn_map_keys();
-
+#endif
         case rt_fn_UNDEFINED:
             break;
     }

--- a/src/runtime/functions/module_assert.c.h
+++ b/src/runtime/functions/module_assert.c.h
@@ -1,0 +1,49 @@
+#ifndef RT_FN_MODULE_ASSERT_C_H
+#define RT_FN_MODULE_ASSERT_C_H
+
+#include <stdbool.h>
+
+#include "runtime/data/Data.h"
+#include "runtime/data/DataList.h"
+#include "runtime/functions.h"
+#include "runtime/functions/module_assert.h"
+#include "runtime/io.h"
+
+rt_Data_t rt_fn_assert_type()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t type = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(type, rt_DATA_TYPE_I64, "arg 1");
+    if (data.type != type.data.i64) {
+        rt_throw(
+            "assertion failed: argument type '%s', expected '%s'",
+            rt_Data_typename(data),
+            rt_Data_typename((rt_Data_t) { .type = type.data.i64 })
+        );
+    }
+    return rt_Data_bul(true);
+}
+
+rt_Data_t rt_fn_assert_equals()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+    const rt_Data_t data1 = *rt_DataList_getref(args, 0);
+    const rt_Data_t data2 = *rt_DataList_getref(args, 1);
+    if (!rt_Data_isequal(data1, data2))
+        rt_throw("assertion failed: arguments are not equal");
+    return rt_Data_bul(true);
+}
+
+rt_Data_t rt_fn_assert_notnull()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    if (rt_Data_isnull(data))
+        rt_throw("assertion failed: argument is null");
+    return rt_Data_bul(true);
+}
+
+#else
+    #warning re-inclusion of module 'functions/module_assert.c.h'
+#endif

--- a/src/runtime/functions/module_chr.c.h
+++ b/src/runtime/functions/module_chr.c.h
@@ -1,6 +1,126 @@
 #ifndef RT_FN_MODULE_CHR_C_H
 #define RT_FN_MODULE_CHR_C_H
 
+#include <ctype.h>
+#include <limits.h>
+
+#include "runtime/data/Data.h"
+#include "runtime/data/DataList.h"
+#include "runtime/functions.h"
+#include "runtime/functions/module_chr.h"
+
+rt_Data_t rt_fn_chr_isdigit()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(isdigit(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_isalpha()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(isalpha(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_isalnum()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(isalnum(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_islower()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(islower(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_isupper()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(isupper(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_isspace()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_CHR, "arg 0");
+    return rt_Data_bul(isspace(data.data.chr));
+}
+
+rt_Data_t rt_fn_chr_max()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return max char */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_chr(CHAR_MAX);
+    /* else return max of args */
+    char max = CHAR_MIN;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        char val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = (char) data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = (char) data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        max = val > max ? val : max;
+    }
+    return rt_Data_chr(max);
+}
+
+rt_Data_t rt_fn_chr_min()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return min char */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_chr(CHAR_MIN);
+    /* else return min of args */
+    char min = CHAR_MAX;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        char val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = (char) data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = (char) data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        min = val < min ? val : min;
+    }
+    return rt_Data_chr(min);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_chr.c.h'
 #endif

--- a/src/runtime/functions/module_dbg.c.h
+++ b/src/runtime/functions/module_dbg.c.h
@@ -108,6 +108,20 @@ rt_Data_t rt_fn_dbg_callproc()
     return ret;
 }
 
+rt_Data_t rt_fn_dbg_filename()
+{
+    /* get filename from top-1 posn as top refers to this fn in stack */
+    const char *filename = (rt_VarTable_top_proc()-1)->filepath;
+    return rt_Data_str(rt_DataStr_init(filename));
+}
+
+rt_Data_t rt_fn_dbg_lineno()
+{
+    /* get line no from top-1 posn as top refers to this fn in stack */
+    const int64_t lineno = (rt_VarTable_top_proc()-1)->current_line;
+    return rt_Data_i64(lineno);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_dbg.c.h'
 #endif

--- a/src/runtime/functions/module_f64.c.h
+++ b/src/runtime/functions/module_f64.c.h
@@ -6,6 +6,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/functions.h"
+#include "runtime/functions/module_f64.h"
 
 rt_Data_t rt_fn_f64_max()
 {

--- a/src/runtime/functions/module_f64.c.h
+++ b/src/runtime/functions/module_f64.c.h
@@ -1,6 +1,76 @@
 #ifndef RT_FN_MODULE_F64_C_H
 #define RT_FN_MODULE_F64_C_H
 
+#include <float.h>
+
+#include "runtime/data/Data.h"
+#include "runtime/data/DataList.h"
+#include "runtime/functions.h"
+
+rt_Data_t rt_fn_f64_max()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return max double */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_f64(DBL_MAX);
+    /* else return max of args */
+    double max = DBL_MIN;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        double val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        max = val > max ? val : max;
+    }
+    return rt_Data_f64(max);
+}
+
+rt_Data_t rt_fn_f64_min()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return min double */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_f64(DBL_MIN);
+    /* else return min of args */
+    double min = DBL_MAX;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        double val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        min = val < min ? val : min;
+    }
+    return rt_Data_f64(min);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_f64.c.h'
 #endif

--- a/src/runtime/functions/module_i64.c.h
+++ b/src/runtime/functions/module_i64.c.h
@@ -1,6 +1,76 @@
 #ifndef RT_FN_MODULE_I64_C_H
 #define RT_FN_MODULE_I64_C_H
 
+#include <stdint.h>
+
+#include "runtime/data/Data.h"
+#include "runtime/data/DataList.h"
+#include "runtime/functions.h"
+
+rt_Data_t rt_fn_i64_max()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return max int64_t */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_i64(INT64_MAX);
+    /* else return max of args */
+    int64_t max = INT64_MIN;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        int64_t val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        max = val > max ? val : max;
+    }
+    return rt_Data_i64(max);
+}
+
+rt_Data_t rt_fn_i64_min()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+    /* if no args are passed, return min int64_t */
+    if (rt_DataList_length(args) == 0)
+        return rt_Data_i64(INT64_MIN);
+    /* else return min of args */
+    int64_t min = INT64_MAX;
+    for (int i = 0; i < rt_DataList_length(args); ++i) {
+        const rt_Data_t data = *rt_DataList_getref(args, i);
+        int64_t val = 0;
+        switch (data.type) {
+            case rt_DATA_TYPE_BUL:
+                val = data.data.bul ? 1 : 0;
+                break;
+            case rt_DATA_TYPE_CHR:
+                val = data.data.chr;
+                break;
+            case rt_DATA_TYPE_I64:
+                val = data.data.i64;
+                break;
+            case rt_DATA_TYPE_F64:
+                val = data.data.f64;
+                break;
+            default:
+                continue;
+        }
+        min = val < min ? val : min;
+    }
+    return rt_Data_i64(min);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_i64.c.h'
 #endif

--- a/src/runtime/functions/module_i64.c.h
+++ b/src/runtime/functions/module_i64.c.h
@@ -6,6 +6,7 @@
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/functions.h"
+#include "runtime/functions/module_i64.h"
 
 rt_Data_t rt_fn_i64_max()
 {
@@ -29,7 +30,7 @@ rt_Data_t rt_fn_i64_max()
                 val = data.data.i64;
                 break;
             case rt_DATA_TYPE_F64:
-                val = data.data.f64;
+                val = (int64_t) data.data.f64;
                 break;
             default:
                 continue;
@@ -61,7 +62,7 @@ rt_Data_t rt_fn_i64_min()
                 val = data.data.i64;
                 break;
             case rt_DATA_TYPE_F64:
-                val = data.data.f64;
+                val = (int64_t) data.data.f64;
                 break;
             default:
                 continue;

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -152,11 +152,13 @@ rt_Data_t rt_fn_io_fread()
     );
 
     rt_DataStr_t *strbuf = rt_DataStr_init("");
-    char buffer[4096] = "";
+    char buffer[1024] = "";
     size_t buff_used = 0;
 
     /* read file in chunks of 4096 bytes and append to strbuf */
-    while ((buff_used = fread(buffer, sizeof(char), 4096, fp)) > 0) {
+    while ((buff_used = fread(buffer, sizeof(char), 1023, fp)) > 0) {
+        /* terminate the string */
+        buffer[buff_used] = '\0';
         /* check for errors */
         int error_num = errno;
         if (ferror(fp)) {

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -139,6 +139,24 @@ rt_Data_t rt_fn_io_input()
     return ret;
 }
 
+rt_Data_t rt_fn_io_fexists()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+
+    const rt_Data_t filename = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(filename, rt_DATA_TYPE_STR, "arg 0");
+
+    char *filename_str = rt_Data_tostr(filename);
+    FILE *fp = fopen(filename_str, "r");
+    if (fp) {
+        fclose(fp);
+        free(filename_str);
+        return rt_Data_bul(true);
+    }
+    free(filename_str);
+    return rt_Data_bul(false);
+}
+
 rt_Data_t rt_fn_io_fread()
 {
     const rt_DataList_t *args = rt_fn_get_valid_args(1);

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -33,13 +33,16 @@ rt_Data_t rt_fn_io_print()
         const rt_Data_t data = *rt_DataList_getref(args, i);
         /* if (rt_Data_isnull(data)) continue; */
         /* print a space before data conditions:
-           - no space before 1st element
-           - no space before `lf` */
-        /* i is not 1st element AND data is not a character */
-        if ((i > 0 && data.type != rt_DATA_TYPE_CHR) ||
-            /* i is not 1st element BUT if data is character it should not be lf */
-            (i > 0 && data.type == rt_DATA_TYPE_CHR && data.data.chr != '\n'))
-                printf(" ");
+            - data is not the first argument
+            - data should not be a new line
+            - data at i-1 should not be a new line */
+        if (i > 0) {
+            rt_Data_t before = *rt_DataList_getref(args, i-1);
+            if (!(before.type == rt_DATA_TYPE_CHR && before.data.chr == '\n') &&
+                !(data.type   == rt_DATA_TYPE_CHR && data.data.chr == '\n')) {
+                bytes += printf(" ");
+            }
+        }
 
         /* call tostr to convert data to string */
         rt_Data_t str = rt_fn_call_handler(

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -70,7 +70,7 @@ rt_Data_t rt_fn_io_input()
     if (type_.type != rt_DATA_TYPE_I64) {
         char *s = rt_Data_tostr(type_);
         rt_throw(
-            "io:input: invalid type parameter: '%s'\n"
+            "invalid type parameter: '%s'\n"
             "valid parameters are bul, chr, i64, f64 or str\n"
             "respective values are %d, %d, %d, %d or %d", s,
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
@@ -79,7 +79,7 @@ rt_Data_t rt_fn_io_input()
     enum rt_DataType_t type = type_.data.i64;
     if (!rt_fn_io_input_type_isvalid(type_.data.i64))
         rt_throw(
-            "io:input: invalid type parameter\n"
+            "invalid type parameter\n"
             "valid parameters are bul, chr, i64, f64 or str\n"
             "respective values are %d, %d, %d, %d or %d",
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
@@ -128,7 +128,7 @@ rt_Data_t rt_fn_io_input()
         case rt_DATA_TYPE_ANY:
         case rt_DATA_TYPE_MAP:
         case rt_DATA_TYPE_PROC: rt_throw(
-            "io:input: invalid type parameter\n"
+            "invalid type parameter\n"
             "valid parameters are bul, chr, i64, f64 or str\n"
             "respective values are %d, %d, %d, %d or %d",
             rt_DATA_TYPE_BUL, rt_DATA_TYPE_CHR, rt_DATA_TYPE_I64, rt_DATA_TYPE_F64, rt_DATA_TYPE_STR);
@@ -143,8 +143,13 @@ rt_Data_t rt_fn_io_fread()
     const rt_Data_t filename = *rt_DataList_getref(args, 0);
     rt_Data_assert_type(filename, rt_DATA_TYPE_STR, "arg 0");
 
-    FILE *fp = fopen(rt_Data_tostr(filename), "rb");
-    if (!fp) rt_throw("io:fread: failed to open file '%s'", rt_Data_tostr(filename));
+    char *filename_str = rt_Data_tostr(filename);
+    FILE *fp = fopen(filename_str, "rb");
+    if (!fp) rt_throw(
+        "failed to open file '%s': %s",
+        filename_str,
+        strerror(errno)
+    );
 
     rt_DataStr_t *strbuf = rt_DataStr_init("");
     char buffer[4096] = "";
@@ -152,12 +157,20 @@ rt_Data_t rt_fn_io_fread()
 
     /* read file in chunks of 4096 bytes and append to strbuf */
     while ((buff_used = fread(buffer, sizeof(char), 4096, fp)) > 0) {
+        /* check for errors */
+        int error_num = errno;
+        if (ferror(fp)) {
+            fclose(fp);
+            rt_throw("failed to read from file '%s': %s",
+                filename_str, strerror(error_num));
+        }
         rt_DataStr_t *chunk = rt_DataStr_init(buffer);
         rt_DataStr_concat(strbuf, chunk);
         rt_DataStr_destroy(&chunk);
     }
 
     fclose(fp);
+    free(filename_str);
     return rt_Data_str(strbuf);
 }
 
@@ -172,13 +185,26 @@ rt_Data_t rt_fn_io_fwrite()
     char *data_str = rt_Data_tostr(data);
     size_t bytes = strlen(data_str);
 
-    FILE *fp = fopen(rt_Data_tostr(filename), "wb");
-    if (!fp) rt_throw("io:fwrite: failed to open file '%s'", rt_Data_tostr(filename));
+    char *filename_str = rt_Data_tostr(filename);
+    FILE *fp = fopen(filename_str, "wb");
+    if (!fp) rt_throw(
+        "failed to open file '%s': %s",
+        filename_str,
+        strerror(errno)
+    );
 
     bytes = fwrite(data_str, sizeof(char), bytes, fp);
+    /* check for errors */
+    int error_num = errno;
+    if (ferror(fp)) {
+        fclose(fp);
+        rt_throw("failed to write to file '%s': %s",
+            filename_str, strerror(error_num));
+    }
 
-    free(data_str);
     fclose(fp);
+    free(filename_str);
+    free(data_str);
     return rt_Data_i64(bytes);
 }
 
@@ -193,13 +219,26 @@ rt_Data_t rt_fn_io_fappend()
     char *data_str = rt_Data_tostr(data);
     size_t bytes = strlen(data_str);
 
-    FILE *fp = fopen(rt_Data_tostr(filename), "ab");
-    if (!fp) rt_throw("io:fappend: failed to open file '%s'", rt_Data_tostr(filename));
+    char *filename_str = rt_Data_tostr(filename);
+    FILE *fp = fopen(filename_str, "ab");
+    if (!fp) rt_throw(
+        "failed to open file '%s': %s",
+        filename_str,
+        strerror(errno)
+    );
 
     bytes = fwrite(data_str, sizeof(char), bytes, fp);
+    /* check for errors */
+    int error_num = errno;
+    if (ferror(fp)) {
+        fclose(fp);
+        rt_throw("failed to write to file '%s': %s",
+            filename_str, strerror(error_num));
+    }
 
-    free(data_str);
     fclose(fp);
+    free(filename_str);
+    free(data_str);
     return rt_Data_i64(bytes);
 }
 
@@ -231,7 +270,7 @@ void rt_fn_io_input_bul(bool *val)
     else if (!strncmp("0", str, len)) *val = false;
     else if (!strncmp("true", str, len)) *val = true;
     else if (!strncmp("false", str, len)) *val = false;
-    else rt_throw("io:input: invalid input for type bul: '%s'", str);
+    else rt_throw("invalid input for type bul: '%s'", str);
     free(str);
 }
 
@@ -242,7 +281,7 @@ void rt_fn_io_input_chr(char *val)
     int len = rt_fn_io_input_str(&str);
     if (len == 1) *val = str[0];
     else if (len == 0) *val = 0;
-    else rt_throw("io:input: invalid input for type chr: '%s'", str);
+    else rt_throw("invalid input for type chr: '%s'", str);
     free(str);
 }
 
@@ -255,7 +294,7 @@ void rt_fn_io_input_i64(int64_t *val)
     errno = 0;
     *val = (int64_t) strtoll(str, &endptr, 10);
     if (errno || *endptr != '\0')
-        rt_throw("io:input: invalid input for type i64: '%s'", str);
+        rt_throw("invalid input for type i64: '%s'", str);
     free(str);
 }
 
@@ -268,7 +307,7 @@ void rt_fn_io_input_f64(double *val)
     errno = 0;
     *val = (double) strtod(str, &endptr);
     if (errno || *endptr != '\0')
-        rt_throw("io:input: invalid input for type f64: '%s'", str);
+        rt_throw("invalid input for type f64: '%s'", str);
     free(str);
 }
 
@@ -281,7 +320,7 @@ int rt_fn_io_input_str(char **val)
     /* remove the newline from result */
     if (len < 0) {
         fprintf(stderr, "%c", '\n');
-        rt_throw("io:input: unknown error occurred");
+        rt_throw("unknown error occurred");
     }
     (*val)[len-1] = 0; len--;
     return len;

--- a/src/runtime/functions/module_it.c.h
+++ b/src/runtime/functions/module_it.c.h
@@ -33,6 +33,13 @@ rt_Data_t rt_fn_it_len()
     return rt_Data_i64(0);
 }
 
+rt_Data_t rt_fn_it_clone()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    return rt_Data_clone(data);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_it.c.h'
 #endif

--- a/src/runtime/functions/module_map.c.h
+++ b/src/runtime/functions/module_map.c.h
@@ -35,7 +35,7 @@ rt_Data_t rt_fn_map_set()
     rt_Data_assert_type(key, rt_DATA_TYPE_STR, "arg 1");
 
     char *key_str = rt_Data_tostr(key);
-    *rt_DataMap_getref(data.data.mp, key_str) = val;
+    rt_DataMap_insert(data.data.mp, key_str, val);
     free(key_str);
 
     return data;

--- a/src/runtime/functions/module_map.c.h
+++ b/src/runtime/functions/module_map.c.h
@@ -1,6 +1,117 @@
 #ifndef RT_FN_MODULE_MAP_C_H
 #define RT_FN_MODULE_MAP_C_H
 
+#include "runtime/data/Data.h"
+#include "runtime/data/DataStr.h"
+#include "runtime/data/DataList.h"
+#include "runtime/data/DataMap.h"
+#include "runtime/functions.h"
+#include "runtime/functions/module_map.h"
+
+rt_Data_t rt_fn_map_get()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t key = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+    rt_Data_assert_type(key, rt_DATA_TYPE_STR, "arg 1");
+
+    char *key_str = rt_Data_tostr(key);
+    const rt_Data_t *val = rt_DataMap_getref(data.data.mp, key_str);
+    free(key_str);
+
+    return val ? *val : rt_Data_null();
+}
+
+rt_Data_t rt_fn_map_set()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(3);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t key = *rt_DataList_getref(args, 1);
+    const rt_Data_t val = *rt_DataList_getref(args, 2);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+    rt_Data_assert_type(key, rt_DATA_TYPE_STR, "arg 1");
+
+    char *key_str = rt_Data_tostr(key);
+    *rt_DataMap_getref(data.data.mp, key_str) = val;
+    free(key_str);
+
+    return data;
+}
+
+rt_Data_t rt_fn_map_erase()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t key = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+    rt_Data_assert_type(key, rt_DATA_TYPE_STR, "arg 1");
+
+    char *key_str = rt_Data_tostr(key);
+    rt_DataMap_del(data.data.mp, key_str);
+    free(key_str);
+
+    return data;
+}
+
+rt_Data_t rt_fn_map_concat()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data1 = *rt_DataList_getref(args, 0);
+    const rt_Data_t data2 = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(data1, rt_DATA_TYPE_MAP, "arg 0");
+    rt_Data_assert_type(data2, rt_DATA_TYPE_MAP, "arg 1");
+
+    rt_DataMap_concat(data1.data.mp, data2.data.mp);
+
+    return data1;
+}
+
+rt_Data_t rt_fn_map_find()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t key = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+    rt_Data_assert_type(key, rt_DATA_TYPE_STR, "arg 1");
+
+    if (data.type != rt_DATA_TYPE_MAP)
+        return rt_Data_null();
+
+    char *key_str = rt_Data_tostr(key);
+    rt_Data_t *val = rt_DataMap_getref(data.data.mp, key_str);
+    free(key_str);
+
+    return val ? rt_Data_bul(true) : rt_Data_bul(false);
+}
+
+rt_Data_t rt_fn_map_keys()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+
+    rt_DataList_t *keys = rt_DataList_init();
+    for (
+        rt_DataMap_iter_t it = rt_DataMap_begin(data.data.mp);
+        it != rt_DataMap_end(data.data.mp);
+        ++it
+    ) {
+        if (!rt_DataMap_exists(data.data.mp, it)) continue;
+        const rt_DataMap_Entry_t *entry = rt_DataMap_get(data.data.mp, it);
+        rt_DataStr_t *key = rt_DataStr_init(entry->key);
+        rt_DataList_append(keys, rt_Data_str(key));
+    }
+
+    return rt_Data_list(keys);
+}
+
 #else
     #warning re-inclusion of module 'functions/module_map.c.h'
 #endif

--- a/src/runtime/functions/module_str.c.h
+++ b/src/runtime/functions/module_str.c.h
@@ -38,6 +38,32 @@ rt_Data_t rt_fn_str_compare()
     return rt_Data_i64(rt_DataStr_compare(data1.data.str, data2.data.str));
 }
 
+rt_Data_t rt_fn_str_toupper()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+
+    /* make sure both are valid types and if not throw an error */
+    rt_Data_assert_type(data, rt_DATA_TYPE_STR, "arg 0");
+
+    /* convert and return */
+    rt_DataStr_toupper(data.data.str);
+    return data;
+}
+
+rt_Data_t rt_fn_str_tolower()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+
+    /* make sure both are valid types and if not throw an error */
+    rt_Data_assert_type(data, rt_DATA_TYPE_STR, "arg 0");
+
+    /* convert and return */
+    rt_DataStr_tolower(data.data.str);
+    return data;
+}
+
 rt_Data_t rt_fn_str_append()
 {
     const rt_DataList_t *args = rt_fn_get_valid_args(2);

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -57,6 +57,13 @@ rt_Data_t rt_fn_type()
     return rt_VarTable_typeid_any;
 }
 
+rt_Data_t rt_fn_clone()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(1);
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    return rt_Data_clone(data);
+}
+
 #else
     #warning re-inclusion of module 'functions/nomodule.c.h'
 #endif

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -57,13 +57,6 @@ rt_Data_t rt_fn_type()
     return rt_VarTable_typeid_any;
 }
 
-rt_Data_t rt_fn_clone()
-{
-    const rt_DataList_t *args = rt_fn_get_valid_args(1);
-    const rt_Data_t data = *rt_DataList_getref(args, 0);
-    return rt_Data_clone(data);
-}
-
 #else
     #warning re-inclusion of module 'functions/nomodule.c.h'
 #endif

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -4,14 +4,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "io.h"
 #include "runtime/data/Data.h"
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataList.h"
 #include "runtime/functions.h"
 #include "runtime/functions/nomodule.h"
 #include "runtime/VarTable.h"
-#include "runtime/io.h"
 
 rt_Data_t rt_fn_isnull()
 {

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -1,6 +1,7 @@
 #ifndef FN_NOMODULE_C_H
 #define FN_NOMODULE_C_H
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "io.h"
@@ -10,6 +11,7 @@
 #include "runtime/functions.h"
 #include "runtime/functions/nomodule.h"
 #include "runtime/VarTable.h"
+#include "runtime/io.h"
 
 rt_Data_t rt_fn_isnull()
 {
@@ -55,6 +57,17 @@ rt_Data_t rt_fn_type()
                 rt_VarTable_rsv_null : rt_VarTable_typeid_any;
     }
     return rt_VarTable_typeid_any;
+}
+
+rt_Data_t rt_fn_cast()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    const rt_Data_t typeid = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(typeid, rt_DATA_TYPE_I64, "arg 1");
+
+    return rt_Data_cast(data, typeid.data.i64);
 }
 
 #else


### PR DESCRIPTION
- added rt fn declarations
- added fn
- rm unimpl fn
- added a clone method
- updated docs
- added a global proc variable
- added lvalue flag: prevents shit like x.y() = 7
- added another test
- na
- na
- module str: added toupper and tolower
- better error o/p: io:f* fn
- bugfix: null term str
- io: updated printing
- updated docs
- added chr module
- added map module
- bugfix: assigning via getref w/out modf caused 1 less rc
- updated docs; mv clone to it:clone
- added dbg:lineno and dbg:filename
- v0.11 and updated examples
- updated docs
- added cast fn
- na
- added module: assert
- added assert example
- na
