### PR TITLE
v2.0 Beta: Major API changes

### DIFF
--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -12,71 +12,62 @@ However, it introduces its own unique features and has a limited set of datatype
 Shsc is a dynamically and weakly typed language with coercion rules that make sense (unlike JS).
 
 ## Index
-- [File structure](#file-structure)
-- [Code organization](#code-organization)
+- [File Structure](#file-structure)
+- [Code Organization](#code-organization)
     - [Indentation](#indentation)
-    - [Module declaration](#module-declaration)
-    - [Pseudo sub-modules](#pseudo-sub-modules)
-    - [Default main module](#default-main-module)
-    - [Module access](#module-access)
-    - [Procedure declaration](#procedure-declaration)
-    - [Entry point](#entry-point)
-    - [Naming collision](#naming-collision)
-    - [End of file](#end-of-file)
-- [Valid identifiers](#valid-identifiers)
-    - [The dollar sign](#the-dollar-sign)
+    - [Module Declaration](#module-declaration)
+    - [Pseudo Sub Modules](#pseudo-sub-modules)
+    - [Default `main` Module](#default-main-module)
+    - [Module Access](#module-access)
+    - [Procedure Declaration](#procedure-declaration)
+    - [Entry Point](#entry-point)
+    - [Naming Collision](#naming-collision)
+    - [End of File](#end-of-file)
+- [Valid Identifiers](#valid-identifiers)
+    - [The Dollar Operator](#the-dollar-operator)
 - [Statements](#statements)
-    - [Variable declaration](#variable-declaration)
-    - [Variable shadowing](#variable-shadowing)
+    - [Variable Declaration](#variable-declaration)
+    - [Variable Re-declaration](#variable-re-declaration)
     - [Constants](#constants)
-        - [Lazy const](#lazy-const)
-    - [Weak refs](#weak-refs)
-        - [Weak ref behaviour](#weak-ref-behaviour)
+        - [Lazy Const](#lazy-const)
+    - [Weak References](#weak-references)
+        - [Weak ref Behaviour](#weak-ref-behaviour)
     - [Semicolons](#semicolons)
-        - [Example](#example)
-- [If statements](#if-statements)
-    - [Example 1](#example-1)
-    - [Example 2](#example-2)
-- [While loops](#while-loops)
-    - [Example](#example-1)
-- [For loops](#for-loops)
-    - [Default increment](#default-increment)
-    - [Specified increment](#specified-increment)
+- [If Statements](#if-statements)
+- [While Loops](#while-loops)
+- [For Loops](#for-loops)
+    - [Default Increment](#default-increment)
+    - [Specified Increment](#specified-increment)
     - [Iterable](#iterable)
-- [Block statement](#block-statement)
+- [Block Statement](#block-statement)
 - [Procedures](#procedures)
-    - [Example](#example-2)
-    - [Procedure arguments](#procedure-arguments)
-    - [Named arguments](#named-arguments)
+    - [Procedure Arguments](#procedure-arguments)
+    - [Named Arguments](#named-arguments)
     - [Arguments to `main:main`](#arguments-to-mainmain)
-    - [Procedure context](#procedure-context)
+    - [Procedure Context](#procedure-context)
+    - [Rudimentary OOP](#rudimentary-oop)
 - [Lambdas](#lambdas)
-    - [Example](#example-3)
 - [Interop with C](#interop-with-c)
 - [Expressions](#expressions)
-    - [Ternary expression](#ternary-expression)
+    - [Ternary Expression](#ternary-expression)
     - [Assignments](#assignments)
-        - [Example](#example-3)
-- [Data and literals](#data-and-literals)
+- [Data and Literals](#data-and-literals)
     - [Coercion Rules](#coercion-rules)
-    - [Special types](#special-types)
-    - [Hidden types](#hidden-types)
-    - [Special global variables](#special-global-variables)
-    - [Properties of Types map](#properties-of-types-map)
-    - [Memory management](#memory-management)
-    - [Memory allocation](#memory-allocation)
-        - [Example](#example-4)
-    - [Memory ownership](#memory-ownership)
-        - [Accumulator](#accumulator)
-        - [Circular references](#circular-references)
-    - [Format strings](#format-strings)
+    - [Special Types](#special-types)
+    - [Hidden Types](#hidden-types)
+    - [Reserved Global Variables](#reserved-global-variables)
+    - [The Global Types Map](#the-global-types-map)
+    - [Memory Management](#memory-management)
+    - [Memory Allocation](#memory-allocation)
+    - [Memory Ownership](#memory-ownership)
+        - [The Accumulator](#the-accumulator)
+        - [Circular References](#circular-references)
+    - [Format Strings](#format-strings)
     - [Lists](#lists)
-        - [Example](#example-5)
     - [Maps](#maps)
-        - [Example](#example-6)
-    - [One-time Map Lock](#one-time-map-lock)
-        - [Example](#example-7)
-- [Built-in procedures](#built-in-procedures)
+        - [Map with `const` Keys](#map-with-const-keys)
+        - [One-time Map Lock](#one-time-map-lock)
+- [Built-in Procedures](#built-in-procedures)
     - [Globally available](#globally-available)
     - [Module `assert`](#module-assert)
     - [Module `dbg`](#module-dbg)
@@ -89,11 +80,11 @@ Shsc is a dynamically and weakly typed language with coercion rules that make se
     - [Module `lst`](#module-lst)
     - [Module `map`](#module-map)
 
-## File structure
+## File Structure
 The interpreter accepts file paths as command-line arguments for the files you want to run.
 It parses each file and constructs a data structure that maps module names to a list of defined procedures.
 
-## Code organization
+## Code Organization
 Since this language doesn't recognize files, module declarations are used to organize code.
 If multiple files have the same module declaration, all the procedures from those files will be stored under the same module name.
 
@@ -102,7 +93,7 @@ The parser ignores indentation and whitespaces completely.
 
 Only newlines are significant for statement termination.
 
-### Module declaration
+### Module Declaration
 Each file must start with the following syntax, indicating the module to which the subsequent procedures belong:
 ```lua
 module module_name
@@ -113,7 +104,7 @@ Also, after the module declaration, the same file can't have another module decl
 
 Procedure definitions can be placed only after the module declaration.
 
-### Pseudo sub-modules
+### Pseudo Sub Modules
 Sub-module can be defined as follows
 ```lua
 module Module:Submodule1:Submodule2
@@ -131,7 +122,7 @@ Previously this would be achieved using `Module_Submodule1_Submodule2` but that 
 
 See [examples/oop](../examples/oop/)
 
-### Default main module
+### Default `main` Module
 If the very first line starts with a procedure declaration (without a module name provided), the runtime assumes the module to be `main` by default.
 
 For example:
@@ -148,7 +139,7 @@ proc procname start
 end
 ```
 
-### Module access
+### Module Access
 Modules don't need to be explicitly imported; they're only declared in **line 1** of the file.
 
 To access a procedure from a different module, use the following syntax:
@@ -157,7 +148,7 @@ modulename:procname
 ```
 Replace `modulename` with the appropriate module name and `procname` with the name of the procedure you want to access.
 
-### Procedure declaration
+### Procedure Declaration
 Procedures can only appear after the module declaration.
 
 The basic syntax for declaring a procedure is as follows:
@@ -168,21 +159,21 @@ end
 ```
 The procedure name (`procname`) should be a valid identifier.
 
-### Entry point
+### Entry Point
 Program execution starts at `main:main`, i.e., the main procedure of the main module.
 
-### Naming collision
+### Naming Collision
 If there is a naming collision between procedures in the same module, the runtime will raise an error and stop execution.
 
-### End of file
+### End of File
 Ensure that each file ends with a newline character, or a syntax error will be thrown.
 
-## Valid identifiers
+## Valid Identifiers
 - Should start with either a letter or an underscore.
 - Can have alphanumeric characters and underscores.
 - Note that `$` is not a valid identifier character.
 
-### The dollar sign
+### The Dollar Operator
 The dollar sign is used to access arguments to a procedure. In compiler terms `$` acts as a special operator.
 For details, see [Procedure arguments](#procedure-arguments).
 
@@ -196,7 +187,7 @@ Any variable declared must be given some value.
 
 A good choice is to assign them to `null`.
 
-### Variable declaration
+### Variable Declaration
 You'd use the `var` keyword to create a new variable in current scope.
 ```lua
 proc test start
@@ -204,7 +195,7 @@ proc test start
 end
 ```
 
-### Variable shadowing
+### Variable Re-declaration
 If you use `var` again, the original variable will be destroyed and replaced by the new one.
 
 ```lua
@@ -230,7 +221,7 @@ end
 ```
 A constant cannot be shadowed.
 
-#### Lazy const
+#### Lazy Const
 Lazy `const` allows you to create a variable and later on make it constant.
 ```lua
 proc test start
@@ -239,7 +230,7 @@ proc test start
 end
 ```
 
-### Weak refs
+### Weak References
 You'd use the `weak` keyword to create a weak reference in current scope.
 ```lua
 proc test start
@@ -252,7 +243,7 @@ Weak references are useful for creating circular references.
 
 Note that not using `weak` in a circular reference will cause a memory leak because the language uses reference counting GC. See [Circular references](#circular-references) for more details.
 
-#### Weak ref behaviour
+#### Weak ref Behaviour
 - Not using `weak` keyword automatically creates a strong reference.
 - Thus, strong references can be made to objects via a weak reference. For example:
     ```lua
@@ -275,21 +266,21 @@ If used at the end of a statement, the parser makes no distinction b/w newlines 
 
 Even a combination of the two can be used wherever one desires.
 
-#### Example
+**Example:**
 ```lua
 x = 5; y = 7
 io:print(x, y, lf)
 ```
 
-## If statements
-### Example 1:
+## If Statements
+**Example 1:**
 ```lua
 if condition then
     # code
 end
 ```
 
-### Example 2:
+**Example 2:**
 ```lua
 if condition then
     # code
@@ -301,8 +292,8 @@ end
 ```
 You can also use `elif` instead of `else if`.
 
-## While loops
-### Example
+## While Loops
+**Example:**
 ```lua
 while condition do
     # code
@@ -312,7 +303,7 @@ end
 ## For Loops
 There are 3 kinds of `for` loops.
 
-### Default increment
+### Default Increment
 Increment (or decrement) by 1 depending on the start and end values.
 ```lua
 var start = 10
@@ -321,7 +312,7 @@ for i from start to 0 do
 end
 ```
 
-### Specified increment
+### Specified Increment
 Increment (or decrement) by the value specified.
 ```lua
 var end = 10
@@ -363,14 +354,14 @@ for v in my_iterable do
 end
 ```
 
-## Block statement
+## Block Statement
 Creates an unnamed scope.
 It's pretty much useless.
 
 ## Procedures
 The following is an example of a factorial program that shows how to use procedures.
 
-### Example
+**Example:**
 ```lua
 module main
 
@@ -391,9 +382,9 @@ proc main start
 end
 ```
 
-### Procedure arguments
+### Procedure Arguments
 
-#### Example
+**Example:**
 Four ways to access the first (0th) argument to a procedure.
 ```lua
 var x = $0
@@ -414,9 +405,9 @@ You may also use `$(expr)` or `$[expr]` where `expr` is an expression that evalu
 
 Of course, you may also use the `args` list to access the arguments, as in `args[expr]`.
 
-### Named arguments
+### Named Arguments
 
-#### Example
+**Example:**
 ```lua
 proc foo(a, b, c)
     io:print(a, b, c, lf)
@@ -427,13 +418,13 @@ proc main()
 end
 ```
 
-#### Output
+**Output:**
 ```
 1 2 3
 ```
 
 Named arguments are set to `null` if no argument is passed by the caller.
-#### Example
+**Example:**
 ```lua
 proc foo(a, b, c)
     io:print(a, b, c, lf)
@@ -444,7 +435,7 @@ proc main()
 end
 ```
 
-#### Output
+**Output:**
 ```
 1 2 null
 ```
@@ -452,7 +443,7 @@ end
 ### Arguments to `main:main`
 The arguments to `main:main` are the command-line arguments passed to the interpreter.
 
-### Procedure context
+### Procedure Context
 If the `.` or map membership operator is used to access a reference to a procedure, the procedure context object is set to the parent map.
 
 Note that this works only if a procedure is accessed from a map using the `.` operator.
@@ -461,7 +452,7 @@ The context object can be accessed using the `this` keyword inside a procedure. 
 
 In case there is no context object, `this` will be `null`.
 
-#### OOP Example
+### Rudimentary OOP
 ```lua
 module ComplexNo
 
@@ -519,7 +510,7 @@ All variables must be passed as arguments.
 
 Lambdas also support context objects.
 
-### Example
+**Example:**
 ```lua
 var add = (a, b) -> a + b
 var long_proc = (a, b) -> {
@@ -538,7 +529,7 @@ Expressions are basically C expressions with some additional operators.
 
 Some additions include exponentiation operator (`**`) and floor division (`//`).
 
-### Ternary expression
+### Ternary Expression
 Follows Python syntax.
 
 ```lua
@@ -552,7 +543,7 @@ The language supports `=` and all the shortcut assignments.
 
 An assignment is a part of an expression, which means you can do the same operations as in C.
 
-#### Example
+**Example:**
 ```lua
 x = y = x = 5
 var u = (x = 4) if true else "hi"
@@ -580,22 +571,22 @@ The language supports the following `built-in` literals.
 - Float, int, and char can be coerced among themselves.
 - Bool can be coerced to any type.
 
-### Special types
+### Special Types
 - `null` Null data
 - Interpolable string aka format strings
 
-### Hidden types
+### Hidden Types
 - `interp_str` Is hardly ever used in the runtime. It may serve as a temporary type for format strings.
 - `any` Is hardly used in the runtime, although `null` is a special kind of `any` object that points to `(void*) 0`.
 
-### Special global variables
+### Reserved Global Variables
 These variables must not be assigned to or else the user may face issues.
 - `lf` chr value equal to `'\n'`
 - `null` null data
 - `globals` map of global variables
 - `Types` map of type names to type values
 
-### Properties of Types map
+### The Global Types Map
 These variables must not be assigned to or else the user may face issues.
 - `Types.BUL` i64 value indicating the bul type
 - `Types.CHR` i64 value indicating the chr type
@@ -612,17 +603,17 @@ These variables must not be assigned to or else the user may face issues.
 The term `built-in` is more accurate for these and we will not call these *primitive*s.
 The language has built-in support for complex composite data structures which can be used using the literals syntax.
 
-### Memory management
+### Memory Management
 Memory is managed by allocating data in the heap, and maintaining a reference count.
 
 The reference count is updated when data is assigned among the variables and also the accumulator.
 
 In case the reference count becomes `0`, the data is freed immediately.
 
-### Memory allocation
+### Memory Allocation
 New memory is allocated for every new literal, even if two literals are identical by value.
 
-#### Example
+**Example:**
 ```lua
 var x = "hello world"
 var y = "hello world"
@@ -632,18 +623,19 @@ Results in two seperate copies of the string `"hello world"` being created for t
 
 The same idea is followed for all other literals, including lists and maps.
 
-### Memory ownership
+### Memory Ownership
 Ownership in our case is being able to destroy the data (free memory).
 
 The following takes memory ownership
 - Any variable to whom data is assigned (until reassigned)
 - Accumulator; or else procedure returns won't work (temporarily)
 - Intermediate results are owned by 2 internal temporary variables
+- Global variables owned by the runtime
 
-#### Accumulator
+#### The Accumulator
 The language uses a temporary location called the `accumulator` to store the result of operations and return values.
 
-#### Circular references
+#### Circular References
 This language is unable to detect and manage circular references.
 If a circular reference must be created, it must be a weak reference. See [Weak refs](#weak-refs) for more details.
 
@@ -653,7 +645,7 @@ Avoid using same variables for weak and strong references.
 
 Additionally, using non-weak circular references **WILL** cause memory leak.
 
-### Format strings
+### Format Strings
 ```lua
 var x = "some data"
 var y = 56
@@ -670,7 +662,7 @@ A single list can have multiple datatypes together.
 Although named list, these literals are stored as an **array** of union of multiple types.
 The type is dynamically inferred when an element is accessed.
 
-#### Example
+**Example:**
 ```lua
 proc test start
     var list = ["xyz", 'a', "\n", "001", 'A', "\x41\x41"]
@@ -699,7 +691,7 @@ If that fails an error will occur, otherwise the data will be stored.
 
 When accessing data, key is again converted into string.
 
-#### Example
+**Example:**
 ```lua
 proc test start
     var key5 = "key5"
@@ -726,9 +718,10 @@ Note how order of keys is not maintained.
 
 Also note how data is stringified during conversion to string (printing).
 
-### Map with `const` Keys
+#### Map with `const` Keys
 A map can have `const` keys which prevent modification of the key.
 
+**Example:**
 ```lua
 proc main()
     var p = {}
@@ -745,7 +738,7 @@ shsc: test.shsc:4: cannot modify const variable
     at main:main (test.shsc:4)
 ```
 
-### One-time Map Lock
+#### One-time Map Lock
 The function `map:lockonce(map, i64)` is used to lock a map. It takes a map and a locking ID as arguments.
 
 Once locked, the map can't be unlocked.
@@ -757,7 +750,7 @@ The latter diasllows modification of existing keys but allows addition or remova
 
 A combination of both can be used to create a read-only map. An example of such a map is the [`Types`](#properties-of-types-map) map provided by the runtime.
 
-#### Example
+**Example:**
 ```lua
 proc main()
     var mp = {
@@ -786,7 +779,7 @@ shsc: examples/lockonce.shsc:15: map is locked from modification with lock id 0x
 
 Note that a lock ID of `0xDEAF` indicates that the map is locked and reserved. It must not be used by the user.
 
-## Built-in procedures
+## Built-in Procedures
 The language supports the following built-in procedures (within built-in modules)
 
 | -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map      |
@@ -807,7 +800,7 @@ The language supports the following built-in procedures (within built-in modules
 | -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -        |
 | -      | -       | -        | -       | -     | -       | -   | -   | sort    | sort    | -        |
 
-#### Globally available
+#### Globally Gvailable
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of the [global variables for types](#global-variables-for-types)

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -726,11 +726,36 @@ Note how order of keys is not maintained.
 
 Also note how data is stringified during conversion to string (printing).
 
+### Map with `const` Keys
+A map can have `const` keys which prevent modification of the key.
+
+```lua
+proc main()
+    var p = {}
+    p.x = const 5
+    p.x = 11
+end
+```
+
+Note that keys can't be const marked using the map literal syntax. Instead it uses the [`lazy const`](#lazy-const) syntax.
+
+**Output:**
+```
+shsc: test.shsc:4: cannot modify const variable
+    at main:main (test.shsc:4)
+```
+
 ### One-time Map Lock
 The function `map:lockonce(map, i64)` is used to lock a map. It takes a map and a locking ID as arguments.
 
 Once locked, the map can't be unlocked.
 Keys can't be added or removed from a locked map.
+They can however be modified.
+
+Difference between `map:lockonce` and using `const` is that the former allows modification of the map but disallows addition or removal of keys.
+The latter diasllows modification of existing keys but allows addition or removal of keys.
+
+A combination of both can be used to create a read-only map. An example of such a map is the [`Types`](#properties-of-types-map) map provided by the runtime.
 
 #### Example
 ```lua
@@ -746,15 +771,17 @@ proc main()
         }
     }
 
-    map:lockonce(mp, 1)
-    map["key5"] = "value5"
+    map:lockonce(mp, 0xDEAD)
+    mp.key1 = 112
+    mp.key5 = "value5"
 end
+
 ```
 
 **Output:**
 ```
-shsc: examples/lockonce.shsc:14: map is locked from modification with lock id 0x1
-    at main:main (examples/lockonce.shsc:14)
+shsc: examples/lockonce.shsc:15: map is locked from modification with lock id 0xDEAD
+    at main:main (examples/lockonce.shsc:15)
 ```
 
 Note that a lock ID of `0xDEAF` indicates that the map is locked and reserved. It must not be used by the user.

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -815,7 +815,7 @@ The language supports the following built-in procedures (within built-in modules
 | -      | -       | -        | -       | -     | -       | -   | -   | tof64   | -       | -        |
 | -      | -       | -        | -       | -     | -       | -   | -   | sort    | sort    | -        |
 
-#### Globally Gvailable
+#### Globally Available
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
 - `type(any)` returns one of items from [`Types`](#the-global-types-map) map

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -356,7 +356,22 @@ end
 
 ## Block Statement
 Creates an unnamed scope.
-It's pretty much useless.
+
+**Example:**
+```lua
+{
+    var x = 5
+    io:print(x, lf)
+}
+```
+
+**Alternative:**
+```lua
+block
+    var x = 5
+    io:print(x, lf)
+end
+```
 
 ## Procedures
 The following is an example of a factorial program that shows how to use procedures.

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -763,7 +763,7 @@ They can however be modified.
 Difference between `map:lockonce` and using `const` is that the former allows modification of the map but disallows addition or removal of keys.
 The latter diasllows modification of existing keys but allows addition or removal of keys.
 
-A combination of both can be used to create a read-only map. An example of such a map is the [`Types`](#properties-of-types-map) map provided by the runtime.
+A combination of both can be used to create a read-only map. An example of such a map is the [`Types`](#the-global-types-map) map provided by the runtime.
 
 **Example:**
 ```lua

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -785,14 +785,14 @@ The language supports the following built-in procedures (within built-in modules
 | -      | assert  | dbg      | io      | it    | chr     | i64 | f64 | str     | lst     | map      |
 |--------|---------|----------|---------|-------|---------|-----|-----|---------|---------|----------|
 | isnull | type    | typename | print   | len   | max     | max | max | equals  | equals  | -        |
-| tostr  | equals  | refcnt   | input   | clone | min     | min | min | compare | compare | -        |
-| type   | notnull | id       | fexists | -     | isdigit | -   | -   | tolower | -       | -        |
-| cast   | -       | callproc | fread   | -     | isalpha | -   | -   | toupper | -       | -        |
-| -      | -       | filename | fwrite  | -     | isalnum | -   | -   | append  | append  | set      |
-| -      | -       | lineno   | fappend | -     | islower | -   | -   | insert  | insert  | get      |
-| -      | -       | -        | libopen | -     | isupper | -   | -   | erase   | erase   | erase    |
-| -      | -       | -        | libsym  | -     | isspace | -   | -   | concat  | concat  | concat   |
-| -      | -       | -        | -       | -     | -       | -   | -   | reverse | reverse | -        |
+| tostr  | equals  | refcnt   | println | clone | min     | min | min | compare | compare | -        |
+| type   | notnull | id       | input   | -     | isdigit | -   | -   | tolower | -       | -        |
+| cast   | -       | callproc | fexists | -     | isalpha | -   | -   | toupper | -       | -        |
+| -      | -       | filename | fread   | -     | isalnum | -   | -   | append  | append  | set      |
+| -      | -       | lineno   | fwrite  | -     | islower | -   | -   | insert  | insert  | get      |
+| -      | -       | -        | fappend | -     | isupper | -   | -   | erase   | erase   | erase    |
+| -      | -       | -        | libopen | -     | isspace | -   | -   | concat  | concat  | concat   |
+| -      | -       | -        | libsym  | -     | -       | -   | -   | reverse | reverse | -        |
 | -      | -       | -        | -       | -     | -       | -   | -   | substr  | sublist | keys     |
 | -      | -       | -        | -       | -     | -       | -   | -   | find    | find    | find     |
 | -      | -       | -        | -       | -     | -       | -   | -   | split   | join    | lockonce |
@@ -828,6 +828,7 @@ The language supports the following built-in procedures (within built-in modules
 File I/O functions will not create a file if it doesn't exist.
 
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
+- `io:printl(any, ...)` prints string form of data (calls `tostr`) and appends a newline
 - `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see the [`Types`](#the-global-types-map) map
 - `io:fexists(str)` returns true if file exists, else false
 - `io:fread(str)` reads a file and returns a string; the first argument is the file path

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -753,8 +753,8 @@ end
 
 **Output:**
 ```
-shsc: test.shsc:14: map is locked from modification with lock id 0x1
-    at main:main (test.shsc:14)
+shsc: examples/lockonce.shsc:14: map is locked from modification with lock id 0x1
+    at main:main (examples/lockonce.shsc:14)
 ```
 
 Note that a lock ID of `0xDEAF` indicates that the map is locked and reserved. It must not be used by the user.

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -399,25 +399,23 @@ end
 
 ### Procedure Arguments
 
+##### Deprecated
+
 **Example:**
-Four ways to access the first (0th) argument to a procedure.
 ```lua
 var x = $0
 var y = $[0]
 var z = $(0)
 var w = args[0]
 ```
-
+Four ways to access the first (0th) argument to a procedure.
 Arguments to a procedure is defined by the actual parameters (i.e. at the caller side).
-
-Procedures have no prototypes or formal parameters.
+Procedures have no prototypes.
 
 Arguments are stored in the `args` built-in `lst` type variable.
-
 However, you may access arguments using the syntax `$i` where `i` is and identifier or literal that evaluates to a valid `i64` index.
 
 You may also use `$(expr)` or `$[expr]` where `expr` is an expression that evaluates to a valid `i64` index.
-
 Of course, you may also use the `args` list to access the arguments, as in `args[expr]`.
 
 ### Named Arguments

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -175,7 +175,7 @@ Ensure that each file ends with a newline character, or a syntax error will be t
 
 ### The Dollar Operator
 The dollar sign is used to access arguments to a procedure. In compiler terms `$` acts as a special operator.
-For details, see [Procedure arguments](#procedure-arguments).
+For details, see [Procedure Arguments](#procedure-arguments).
 
 ## Statements
 All statements end with a newline.
@@ -241,7 +241,7 @@ end
 
 Weak references are useful for creating circular references.
 
-Note that not using `weak` in a circular reference will cause a memory leak because the language uses reference counting GC. See [Circular references](#circular-references) for more details.
+Note that not using `weak` in a circular reference will cause a memory leak because the language uses reference counting GC. See [Circular References](#circular-references) for more details.
 
 #### Weak ref Behaviour
 - Not using `weak` keyword automatically creates a strong reference.
@@ -637,7 +637,7 @@ The language uses a temporary location called the `accumulator` to store the res
 
 #### Circular References
 This language is unable to detect and manage circular references.
-If a circular reference must be created, it must be a weak reference. See [Weak refs](#weak-refs) for more details.
+If a circular reference must be created, it must be a weak reference. See [Weak References](#weak-references) for more details.
 
 Running `tostr` or `io:print` on an object having a circular reference will most likely result in stack overflow or Segmentation fault.
 
@@ -730,7 +730,7 @@ proc main()
 end
 ```
 
-Note that keys can't be const marked using the map literal syntax. Instead it uses the [`lazy const`](#lazy-const) syntax.
+Note that keys can't be const marked using the map literal syntax. Instead it uses the [`Lazy Const`](#lazy-const) syntax.
 
 **Output:**
 ```
@@ -803,8 +803,8 @@ The language supports the following built-in procedures (within built-in modules
 #### Globally Gvailable
 - `isnull(any)` returns true if data is `null`, else false
 - `tostr(any)` stringifies a built-in; for lists and maps, it's JSON-like stringification; for circular references, it'll most likely result in stack overflow or segmentation fault
-- `type(any)` returns one of the [global variables for types](#global-variables-for-types)
-- `cast(any, i64)` casts data to a type; the second argument is one of the [global variables for types](#global-variables-for-types)
+- `type(any)` returns one of items from [`Types`](#the-global-types-map) map
+- `cast(any, i64)` casts data to a type; the second argument is one of the items from [`Types`](#the-global-types-map)
 - `max(any, ...)` returns the greatest of the arguments; returns `null` if no arguments are passed
 - `max(lst)` returns the greatest of the items in the list; returns `null` if list is empty
 - `min(any, ...)` returns the smallest of the arguments; returns `null` if no arguments are passed
@@ -828,7 +828,7 @@ The language supports the following built-in procedures (within built-in modules
 File I/O functions will not create a file if it doesn't exist.
 
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
-- `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see [global variables for types](#global-variables-for-types)
+- `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see the [`Types`](#the-global-types-map) map
 - `io:fexists(str)` returns true if file exists, else false
 - `io:fread(str)` reads a file and returns a string; the first argument is the file path
 - `io:fwrite(str, str)` writes a string to a file; the first argument is the file path

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -68,7 +68,7 @@ Shsc is a dynamically and weakly typed language with coercion rules that make se
         - [Map with `const` Keys](#map-with-const-keys)
         - [One-time Map Lock](#one-time-map-lock)
 - [Built-in Procedures](#built-in-procedures)
-    - [Globally available](#globally-available)
+    - [Globally Available](#globally-available)
     - [Module `assert`](#module-assert)
     - [Module `dbg`](#module-dbg)
     - [Module `io`](#module-io)

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -828,7 +828,7 @@ The language supports the following built-in procedures (within built-in modules
 File I/O functions will not create a file if it doesn't exist.
 
 - `io:print(any, ...)` prints string form of data (calls `tostr`)
-- `io:printl(any, ...)` prints string form of data (calls `tostr`) and appends a newline
+- `io:println(any, ...)` prints string form of data (calls `tostr`) and appends a newline
 - `io:input(str, i64)` where the first argument is the prompt and the second argument is the type of input, see the [`Types`](#the-global-types-map) map
 - `io:fexists(str)` returns true if file exists, else false
 - `io:fread(str)` reads a file and returns a string; the first argument is the file path

--- a/docs/LanguageDocs.md
+++ b/docs/LanguageDocs.md
@@ -439,6 +439,7 @@ end
 ```
 
 Named arguments are set to `null` if no argument is passed by the caller.
+
 **Example:**
 ```lua
 proc foo(a, b, c)

--- a/examples/callproc.shsc
+++ b/examples/callproc.shsc
@@ -1,7 +1,7 @@
 proc main()
-    var x = dbg:callproc(null, "io", "input", ["enter a number: ", i64]);
+    var x = dbg:callproc(null, "io", "input", ["enter a number: ", Types.I64]);
     dbg:callproc(null, "io", "print", ["you entered:", x, lf]);
     # without using dbg:callproc
-    var y = io:input("enter a number: ", i64);
+    var y = io:input("enter a number: ", Types.I64);
     io:print("you entered:", y, lf);
 end

--- a/examples/factorial.shsc
+++ b/examples/factorial.shsc
@@ -5,7 +5,7 @@ proc input(prompt, type)
 end
 
 proc main()
-    var inp = input("Enter a number: ", i64)
+    var inp = input("Enter a number: ", Types.I64)
     var res = factorial(inp)
     io:print(f"result = {res}\n")
 end

--- a/examples/fibonacci.shsc
+++ b/examples/fibonacci.shsc
@@ -1,7 +1,7 @@
 module main
 
 proc main()
-    var inp = io:input("Enter a number: ", i64)
+    var inp = io:input("Enter a number: ", Types.I64)
     var res = fibonacci(inp)
     io:print(f"result = {res}\n")
 end

--- a/examples/globalvars.shsc
+++ b/examples/globalvars.shsc
@@ -1,0 +1,10 @@
+proc foo()
+    io:print("x1 =", globals.x, lf)
+    globals.x = globals.x + 10
+end
+
+proc main()
+    globals.x = 5
+    foo()
+    io:print("x2 =", globals.x, lf)
+end

--- a/examples/helloworld.shsc
+++ b/examples/helloworld.shsc
@@ -3,7 +3,7 @@ module main
 proc test(string, list)
     var times = list
     for x in times do
-        var name = io:input(f"Enter name {x}: ", str)
+        var name = io:input(f"Enter name {x}: ", Types.STR)
         var bytes = io:print(f"Hello {name}!",
                               "It's a beautiful world!", lf)
         io:print(f"Printed: {bytes} Bytes", lf, lf)

--- a/examples/inbuiltfn.shsc
+++ b/examples/inbuiltfn.shsc
@@ -1,7 +1,7 @@
 proc main()
     var x = [1,2,3,4,5]
-    var a = i64
-    var b = f64
+    var a = Types.I64
+    var b = Types.F64
     var c = 'c'
     var d = null
     var e = "xyz"

--- a/examples/inheritance/base.shsc
+++ b/examples/inheritance/base.shsc
@@ -1,8 +1,8 @@
 module inher:Base
 
 proc init(x, y)
-    assert:type(x, i64)
-    assert:type(y, i64)
+    assert:type(x, Types.I64)
+    assert:type(y, Types.I64)
     # new object
     var obj = {
         x: x,

--- a/examples/lockonce.shsc
+++ b/examples/lockonce.shsc
@@ -11,5 +11,6 @@ proc main()
     }
 
     map:lockonce(mp, 0xDEAD)
-    mp["key5"] = "value5"
+    mp.key1 = 112
+    mp.key5 = "value5"
 end

--- a/examples/lockonce.shsc
+++ b/examples/lockonce.shsc
@@ -1,0 +1,15 @@
+proc main()
+    var mp = {
+        key1: true,
+        key2: 78,
+        "key3": 1222,
+        "key4": {
+            alpha: "hi",
+            "beta": 67,
+            "gamma": "\x05\x0a"
+        }
+    }
+
+    map:lockonce(mp, 1)
+    mp["key5"] = "value5"
+end

--- a/examples/lockonce.shsc
+++ b/examples/lockonce.shsc
@@ -10,6 +10,6 @@ proc main()
         }
     }
 
-    map:lockonce(mp, 1)
+    map:lockonce(mp, 0xDEAD)
     mp["key5"] = "value5"
 end

--- a/examples/oop/ComplexNo.shsc
+++ b/examples/oop/ComplexNo.shsc
@@ -1,8 +1,8 @@
 module math:ComplexNo
 
 proc init(x, y)
-    x = cast(x, f64)
-    y = cast(y, f64)
+    x = cast(x, Types.F64)
+    y = cast(y, Types.F64)
     # create new object from the arguments
     var z = { x: x, y: y }
     # bind proccedures to the object as methods

--- a/examples/passing_lambdas.shsc
+++ b/examples/passing_lambdas.shsc
@@ -2,8 +2,8 @@ module main
 
 # insertion sort
 proc sort(list, comparator)
-    assert:type(list, lst)
-    assert:type(comparator, lambda)
+    assert:type(list, Types.LST)
+    assert:type(comparator, Types.LAMBDA)
     var i = 0
     var n = it:len(list)
     while i < n do

--- a/examples/testassert.shsc
+++ b/examples/testassert.shsc
@@ -1,6 +1,6 @@
 proc main()
-    assert:type({}, map)
-    assert:type([], lst)
+    assert:type({}, Types.MAP)
+    assert:type([], Types.LST)
     assert:equals(1.0, 1)
     assert:equals(1.0, {})
 end

--- a/examples/testnum.shsc
+++ b/examples/testnum.shsc
@@ -1,5 +1,5 @@
 proc main()
-    io:print(cast(chr:max(), i64), cast(chr:min(), i64), lf)
+    io:print(cast(chr:max(), Types.I64), cast(chr:min(), Types.I64), lf)
     io:print(+chr:max([1, 'a', 11.5, 69.9]), +chr:min(1, 'a', 11.5, 69.9), lf)
     io:print(chr:isalpha('a'), chr:isalpha('1'), lf)
     io:print(chr:isdigit('a'), chr:isdigit('1'), lf)

--- a/include/globals.h
+++ b/include/globals.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#define VERSION "1.5 Beta"
+#define VERSION "2.0 Beta"
 #define AUTHORS "Aviruk Basak"
 #define GLOBAL_BYTES_BUFFER_LEN (128)
 

--- a/include/runtime/VarTable.h
+++ b/include/runtime/VarTable.h
@@ -52,20 +52,10 @@ struct rt_VarTable_Acc_t{
 
 /* few globally defined variables */
 extern
-rt_Data_t rt_VarTable_rsv_lf,
-/* list of globally defined typename variables */
-          rt_VarTable_typeid_bul,
-          rt_VarTable_typeid_chr,
-          rt_VarTable_typeid_i64,
-          rt_VarTable_typeid_f64,
-          rt_VarTable_typeid_str,
-          rt_VarTable_typeid_lst,
-          rt_VarTable_typeid_any,
-          rt_VarTable_typeid_map,
-          rt_VarTable_typeid_proc,
-          rt_VarTable_typeid_lambda,
-          rt_VarTable_typeid_libhandle,
-          rt_VarTable_rsv_null;
+rt_Data_t rt_VarTable_rsv_Types,
+          rt_VarTable_rsv_lf,
+          rt_VarTable_rsv_null,
+          rt_VarTable_rsv_globals;
 
 /** create a new variable in the current scope */
 void rt_VarTable_create(const char *varname, rt_Data_t value, bool is_const, bool is_weak);
@@ -105,7 +95,7 @@ void rt_VarTable_push_scope();
 /** pop local scope and return result of last expression */
 rt_Data_t rt_VarTable_pop_scope(void);
 
-/** clear memory of the VarTable */
+/** clear memory of the VarTable and destroy an global variables */
 void rt_VarTable_destroy();
 
 #endif

--- a/include/runtime/data/DataMap.h
+++ b/include/runtime/data/DataMap.h
@@ -8,7 +8,7 @@
 #include "runtime/data/Data.h"
 
 enum rt_DataMap_CommonLockIds {
-    RT_DATA_MAP_LOCKID_SYSTEM = 0xDEAD,
+    rt_DATA_MAP_LOCKID_RESERVED = 0xDEAF,
 };
 
 typedef struct {

--- a/include/runtime/data/DataMap.h
+++ b/include/runtime/data/DataMap.h
@@ -7,6 +7,10 @@
 #include "tlib/khash/khash.h"
 #include "runtime/data/Data.h"
 
+enum rt_DataMap_CommonLockIds {
+    RT_DATA_MAP_LOCKID_SYSTEM = 0xDEAD,
+};
+
 typedef struct {
     char *key;
     rt_Data_t value;
@@ -18,6 +22,7 @@ struct rt_DataMap_t {
     khash_t(rt_DataMap_t) *data_map;
     int64_t length;
     int64_t rc;
+    rt_Data_t one_time_lock;
 };
 
 typedef khiter_t rt_DataMap_iter_t;
@@ -36,7 +41,7 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr);
 void rt_DataMap_insert(rt_DataMap_t *mp, const char *key, rt_Data_t value);
 void rt_DataMap_del(rt_DataMap_t *mp, const char *key);
 
-void rt_DataMap_concat(const rt_DataMap_t *mp1, const rt_DataMap_t *mp2);
+void rt_DataMap_concat(rt_DataMap_t *mp1, const rt_DataMap_t *mp2);
 
 const char *rt_DataMap_getkey_copy(const rt_DataMap_t *mp, const char *key);
 /** unlike rt_DataMap_getref, returns NULL if key not found */
@@ -47,6 +52,8 @@ rt_Data_t *rt_DataMap_getref_errnull(const rt_DataMap_t *mp, const char *key);
     on the returned data pointer, that'll take care of reference counts */
 rt_Data_t *rt_DataMap_getref(const rt_DataMap_t *mp, const char *key);
 char *rt_DataMap_tostr(const rt_DataMap_t *mp);
+
+void rt_DataMap_lockonce(rt_DataMap_t *mp, int64_t lockid);
 
 rt_DataMap_iter_t rt_DataMap_begin(rt_DataMap_t *mp);
 rt_DataMap_iter_t rt_DataMap_end(rt_DataMap_t *mp);

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -41,6 +41,7 @@ typedef enum {
     rt_fn_DBG_TIMENOW_PARAM, /* dbg:timenow_param */
 
     rt_fn_IO_PRINT,      /* io:print */
+    rt_fn_IO_PRINTLN,    /* io:println */
     rt_fn_IO_INPUT,      /* io:input */
     rt_fn_IO_FEXISTS,    /* io:exists */
     rt_fn_IO_FREAD,      /* io:fread */

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -101,6 +101,7 @@ typedef enum {
     rt_fn_MAP_CONCAT,    /* map:concat */
     rt_fn_MAP_FIND,      /* map:find */
     rt_fn_MAP_KEYS,      /* map:keys */
+    rt_fn_MAP_LOCKONCE,  /* map:lockonce */
 
     rt_fn_UNDEFINED,
 } rt_fn_FunctionDescriptor_t;

--- a/include/runtime/functions/module_io.h
+++ b/include/runtime/functions/module_io.h
@@ -4,6 +4,7 @@
 #include "runtime/data/Data.h"
 
 rt_Data_t rt_fn_io_print();
+rt_Data_t rt_fn_io_println();
 rt_Data_t rt_fn_io_input();
 rt_Data_t rt_fn_io_fexists();
 rt_Data_t rt_fn_io_fread();

--- a/include/runtime/functions/module_map.h
+++ b/include/runtime/functions/module_map.h
@@ -9,5 +9,6 @@ rt_Data_t rt_fn_map_erase();
 rt_Data_t rt_fn_map_concat();
 rt_Data_t rt_fn_map_find();
 rt_Data_t rt_fn_map_keys();
+rt_Data_t rt_fn_map_lockonce();
 
 #endif

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -36,7 +36,10 @@ int rt_exec(int argc, char **argv)
     if (ctrl == rt_CTRL_CONTINUE)
         rt_throw("unexpected `continue` statement outside loop");
 
-    return rt_VarTable_pop_proc().data.i64;
+    int exitcode = (int) rt_VarTable_pop_proc().data.i64;
+    rt_VarTable_destroy();
+
+    return exitcode;
 }
 
 #include "runtime/data/Data.c.h"

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -66,7 +66,6 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
         rt_DataMap_insert(typesmap, "PROC", proc);
         rt_DataMap_insert(typesmap, "LAMBDA", lambda);
         rt_DataMap_insert(typesmap, "LIBHANDLE", libhandle);
-        rt_DataMap_insert(typesmap, "NULL", rt_VarTable_rsv_null);
         rt_VarTable_rsv_Types = rt_Data_map(typesmap);
         /* increase reference count of the map. if map is assigned to
            a variable and that variable is destroyed, the map should remain.

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -130,6 +130,10 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src, bool is_const, bool 
         if (dest == &rt_VarTable_rsv_globals) rt_throw("cannot modify reserved variable 'globals'");
     }
 
+    /* if dest type is not same as src type, throw error */
+    /* if (!rt_Data_isnull(*dest) && dest->type != src.type) rt_throw("cannot assign value of type '%s' to variable of type '%s'",
+        rt_Data_typename(src), rt_Data_typename(*dest)); */
+
     /* if dest is not lvalue, throw error */
     if (!dest->lvalue) rt_throw("lhs of assignment is not an lvalue");
 

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -73,6 +73,8 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
         rt_Data_increfc(&rt_VarTable_rsv_Types);
         /* lock the type map */
         rt_DataMap_lockonce(typesmap, RT_DATA_MAP_LOCKID_SYSTEM);
+        /* make Types a const */
+        rt_VarTable_rsv_Types.is_const = true;
     }
 
     if (rt_Data_isnull(rt_VarTable_rsv_globals)) {
@@ -82,6 +84,8 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
            a variable and that variable is destroyed, the map should remain.
            thus, we increase the reference count */
         rt_Data_increfc(&rt_VarTable_rsv_globals);
+        /* make globals a const */
+        rt_VarTable_rsv_globals.is_const = true;
     }
 
     if (!strcmp("Types", varname))   return &rt_VarTable_rsv_Types;

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -32,35 +32,62 @@ rt_VarTable_Acc_t rt_vtable_accumulator = {
 
 
 /* few globally defined variables */
-rt_Data_t rt_VarTable_rsv_lf      = { .data.chr = '\n',             .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false, .lvalue = false },
-/* list of globally defined typename variables */
-          rt_VarTable_typeid_bul  = { .data.i64 = rt_DATA_TYPE_BUL, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_chr  = { .data.i64 = rt_DATA_TYPE_CHR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_i64  = { .data.i64 = rt_DATA_TYPE_I64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_f64  = { .data.i64 = rt_DATA_TYPE_F64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_str  = { .data.i64 = rt_DATA_TYPE_STR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_lst  = { .data.i64 = rt_DATA_TYPE_LST, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_any  = { .data.i64 = rt_DATA_TYPE_ANY, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_map  = { .data.i64 = rt_DATA_TYPE_MAP, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_proc = { .data.i64 = rt_DATA_TYPE_PROC,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_lambda = { .data.i64 = rt_DATA_TYPE_LAMBDA,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_typeid_libhandle = { .data.i64 = rt_DATA_TYPE_LIBHANDLE,.type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false },
-          rt_VarTable_rsv_null    = { .data.any = NULL,             .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false, .lvalue = false };
+rt_Data_t rt_VarTable_rsv_Types   = { .data.any = NULL, .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_rsv_lf      = { .data.chr = '\n', .type = rt_DATA_TYPE_CHR, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_rsv_null    = { .data.any = NULL, .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false, .lvalue = false },
+          rt_VarTable_rsv_globals = { .data.any = NULL, .type = rt_DATA_TYPE_ANY, .is_const = true, .is_weak = false, .lvalue = false };
 
 
 rt_Data_t *rt_VarTable_get_globvar(const char *varname)
 {
-    if (!strcmp("lf", varname))   return &rt_VarTable_rsv_lf;
-    if (!strcmp("bul", varname))  return &rt_VarTable_typeid_bul;
-    if (!strcmp("chr", varname))  return &rt_VarTable_typeid_chr;
-    if (!strcmp("i64", varname))  return &rt_VarTable_typeid_i64;
-    if (!strcmp("f64", varname))  return &rt_VarTable_typeid_f64;
-    if (!strcmp("str", varname))  return &rt_VarTable_typeid_str;
-    if (!strcmp("lst", varname))  return &rt_VarTable_typeid_lst;
-    if (!strcmp("map", varname))  return &rt_VarTable_typeid_map;
-    if (!strcmp("proc", varname)) return &rt_VarTable_typeid_proc;
-    if (!strcmp("lambda", varname)) return &rt_VarTable_typeid_lambda;
-    if (!strcmp("null", varname)) return &rt_VarTable_rsv_null;
+    if (rt_Data_isnull(rt_VarTable_rsv_Types)) {
+        rt_DataMap_t *typesmap = rt_DataMap_init();
+
+        rt_Data_t bul = { .data.i64 = rt_DATA_TYPE_BUL, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t chr = { .data.i64 = rt_DATA_TYPE_CHR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t i64 = { .data.i64 = rt_DATA_TYPE_I64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t f64 = { .data.i64 = rt_DATA_TYPE_F64, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t str = { .data.i64 = rt_DATA_TYPE_STR, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t lst = { .data.i64 = rt_DATA_TYPE_LST, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t any = { .data.i64 = rt_DATA_TYPE_ANY, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t map = { .data.i64 = rt_DATA_TYPE_MAP, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t proc = { .data.i64 = rt_DATA_TYPE_PROC, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t lambda = { .data.i64 = rt_DATA_TYPE_LAMBDA, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+        rt_Data_t libhandle = { .data.i64 = rt_DATA_TYPE_LIBHANDLE, .type = rt_DATA_TYPE_I64, .is_const = true, .is_weak = false, .lvalue = false };
+
+        rt_DataMap_insert(typesmap, "BUL", bul);
+        rt_DataMap_insert(typesmap, "CHR", chr);
+        rt_DataMap_insert(typesmap, "I64", i64);
+        rt_DataMap_insert(typesmap, "F64", f64);
+        rt_DataMap_insert(typesmap, "STR", str);
+        rt_DataMap_insert(typesmap, "LST", lst);
+        rt_DataMap_insert(typesmap, "ANY", any);
+        rt_DataMap_insert(typesmap, "MAP", map);
+        rt_DataMap_insert(typesmap, "PROC", proc);
+        rt_DataMap_insert(typesmap, "LAMBDA", lambda);
+        rt_DataMap_insert(typesmap, "LIBHANDLE", libhandle);
+        rt_VarTable_rsv_Types = rt_Data_map(typesmap);
+        /* increase reference count of the map. if map is assigned to
+           a variable and that variable is destroyed, the map should remain.
+           thus, we increase the reference count */
+        rt_Data_increfc(&rt_VarTable_rsv_Types);
+        /* lock the type map */
+        rt_DataMap_lockonce(typesmap, RT_DATA_MAP_LOCKID_SYSTEM);
+    }
+
+    if (rt_Data_isnull(rt_VarTable_rsv_globals)) {
+        rt_DataMap_t *globalsmap = rt_DataMap_init();
+        rt_VarTable_rsv_globals = rt_Data_map(globalsmap);
+        /* increase reference count of the map. if map is assigned to
+           a variable and that variable is destroyed, the map should remain.
+           thus, we increase the reference count */
+        rt_Data_increfc(&rt_VarTable_rsv_globals);
+    }
+
+    if (!strcmp("Types", varname))   return &rt_VarTable_rsv_Types;
+    if (!strcmp("lf", varname))      return &rt_VarTable_rsv_lf;
+    if (!strcmp("null", varname))    return &rt_VarTable_rsv_null;
+    if (!strcmp("globals", varname)) return &rt_VarTable_rsv_globals;
     return NULL;
 }
 
@@ -92,17 +119,10 @@ rt_Data_t *rt_VarTable_modf(rt_Data_t *dest, rt_Data_t src, bool is_const, bool 
     if (!dest) return NULL;
     /* if data is one of the global built-in vars, throw appropriate error */
     {
+        if (dest == &rt_VarTable_rsv_Types)   rt_throw("cannot modify reserved variable 'Types'");
         if (dest == &rt_VarTable_rsv_lf)      rt_throw("cannot modify reserved variable 'lf'");
-        if (dest == &rt_VarTable_typeid_bul)  rt_throw("cannot modify reserved variable 'bul'");
-        if (dest == &rt_VarTable_typeid_chr)  rt_throw("cannot modify reserved variable 'chr'");
-        if (dest == &rt_VarTable_typeid_i64)  rt_throw("cannot modify reserved variable 'i64'");
-        if (dest == &rt_VarTable_typeid_f64)  rt_throw("cannot modify reserved variable 'f64'");
-        if (dest == &rt_VarTable_typeid_str)  rt_throw("cannot modify reserved variable 'str'");
-        if (dest == &rt_VarTable_typeid_lst)  rt_throw("cannot modify reserved variable 'lst'");
-        if (dest == &rt_VarTable_typeid_map)  rt_throw("cannot modify reserved variable 'map'");
-        if (dest == &rt_VarTable_typeid_proc) rt_throw("cannot modify reserved variable 'proc'");
-        if (dest == &rt_VarTable_typeid_lambda) rt_throw("cannot modify reserved variable 'lambda'");
         if (dest == &rt_VarTable_rsv_null)    rt_throw("cannot modify reserved variable 'null'");
+        if (dest == &rt_VarTable_rsv_globals) rt_throw("cannot modify reserved variable 'globals'");
     }
 
     /* if dest is not lvalue, throw error */
@@ -303,7 +323,11 @@ rt_Data_t rt_VarTable_pop_scope(void)
 /** clear memory of the VarTable */
 void rt_VarTable_destroy()
 {
-    io_errndie("rt_VarTable_destroy: unimplemented");
+    /* destroy the global variables */
+    rt_Data_destroy(&rt_VarTable_rsv_Types);
+    rt_Data_destroy(&rt_VarTable_rsv_lf);
+    rt_Data_destroy(&rt_VarTable_rsv_null);
+    rt_Data_destroy(&rt_VarTable_rsv_globals);
     return;
 }
 

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -73,7 +73,7 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
            thus, we increase the reference count */
         rt_Data_increfc(&rt_VarTable_rsv_Types);
         /* lock the type map */
-        rt_DataMap_lockonce(typesmap, RT_DATA_MAP_LOCKID_SYSTEM);
+        rt_DataMap_lockonce(typesmap, rt_DATA_MAP_LOCKID_RESERVED);
         /* make Types a const */
         rt_VarTable_rsv_Types.is_const = true;
     }

--- a/src/runtime/VarTable.c.h
+++ b/src/runtime/VarTable.c.h
@@ -66,6 +66,7 @@ rt_Data_t *rt_VarTable_get_globvar(const char *varname)
         rt_DataMap_insert(typesmap, "PROC", proc);
         rt_DataMap_insert(typesmap, "LAMBDA", lambda);
         rt_DataMap_insert(typesmap, "LIBHANDLE", libhandle);
+        rt_DataMap_insert(typesmap, "NULL", rt_VarTable_rsv_null);
         rt_VarTable_rsv_Types = rt_Data_map(typesmap);
         /* increase reference count of the map. if map is assigned to
            a variable and that variable is destroyed, the map should remain.

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -750,7 +750,7 @@ const char *rt_Data_typename(const rt_Data_t var)
         case rt_DATA_TYPE_INTERP_STR: return "Types.INTERP_STR";
         case rt_DATA_TYPE_LST:        return "Types.LST";
         case rt_DATA_TYPE_MAP:        return "Types.MAP";
-        case rt_DATA_TYPE_ANY:        return var.data.any ? "Types.ANY" : "Types.NULL";
+        case rt_DATA_TYPE_ANY:        return var.data.any ? "Types.ANY" : "null";
         case rt_DATA_TYPE_PROC:       return "Types.PROC";
         case rt_DATA_TYPE_LAMBDA:     return "Types.LAMBDA";
         case rt_DATA_TYPE_LIBHANDLE:  return "Types.LIBHANDLE";

--- a/src/runtime/data/Data.c.h
+++ b/src/runtime/data/Data.c.h
@@ -742,18 +742,18 @@ rt_Data_t rt_Data_cast(const rt_Data_t data, enum rt_DataType_t type)
 const char *rt_Data_typename(const rt_Data_t var)
 {
     switch (var.type) {
-        case rt_DATA_TYPE_BUL:        return "bul";
-        case rt_DATA_TYPE_CHR:        return "chr";
-        case rt_DATA_TYPE_I64:        return "i64";
-        case rt_DATA_TYPE_F64:        return "f64";
-        case rt_DATA_TYPE_STR:        return "str";
-        case rt_DATA_TYPE_INTERP_STR: return "interp_str";
-        case rt_DATA_TYPE_LST:        return "lst";
-        case rt_DATA_TYPE_MAP:        return "map";
-        case rt_DATA_TYPE_ANY:        return var.data.any ? "any" : "null";
-        case rt_DATA_TYPE_PROC:       return "proc";
-        case rt_DATA_TYPE_LAMBDA:     return "lambda";
-        case rt_DATA_TYPE_LIBHANDLE:  return "libhandle";
+        case rt_DATA_TYPE_BUL:        return "Types.BUL";
+        case rt_DATA_TYPE_CHR:        return "Types.CHR";
+        case rt_DATA_TYPE_I64:        return "Types.I64";
+        case rt_DATA_TYPE_F64:        return "Types.F64";
+        case rt_DATA_TYPE_STR:        return "Types.STR";
+        case rt_DATA_TYPE_INTERP_STR: return "Types.INTERP_STR";
+        case rt_DATA_TYPE_LST:        return "Types.LST";
+        case rt_DATA_TYPE_MAP:        return "Types.MAP";
+        case rt_DATA_TYPE_ANY:        return var.data.any ? "Types.ANY" : "Types.NULL";
+        case rt_DATA_TYPE_PROC:       return "Types.PROC";
+        case rt_DATA_TYPE_LAMBDA:     return "Types.LAMBDA";
+        case rt_DATA_TYPE_LIBHANDLE:  return "Types.LIBHANDLE";
     }
     return NULL;
 }

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -154,7 +154,7 @@ void rt_DataMap_concat(rt_DataMap_t *mp1, const rt_DataMap_t *mp2)
     for (khiter_t entry_it = kh_begin(mp2->data_map); entry_it != kh_end(mp2->data_map); ++entry_it) {
         if (!kh_exist(mp2->data_map, entry_it)) continue;
         const char *key = kh_key(mp2->data_map, entry_it);
-        rt_DataMap_insert((rt_DataMap_t*) mp1, key,
+        rt_DataMap_insert(mp1, key,
             kh_value(mp2->data_map, entry_it).value);
     }
 }

--- a/src/runtime/data/DataMap.c.h
+++ b/src/runtime/data/DataMap.c.h
@@ -25,6 +25,9 @@ rt_DataMap_t *rt_DataMap_init()
     /* rc is kept at 0 unless the runtime assigns
        a variable to the data */
     mp->rc = 0;
+    /* a one time lock when set prevents operations
+       like insert and delete, on the map */
+    mp->one_time_lock = rt_Data_null();
     return mp;
 }
 
@@ -102,6 +105,10 @@ void rt_DataMap_destroy(rt_DataMap_t **ptr)
 
 void rt_DataMap_insert(rt_DataMap_t *mp, const char *key, rt_Data_t value)
 {
+    if (!rt_Data_isnull(mp->one_time_lock)) {
+        rt_throw("map is locked from modification with lock id %p", (void*) mp->one_time_lock.data.i64);
+    }
+
     rt_Data_increfc(&value);
     khiter_t entry_it = kh_get(rt_DataMap_t, mp->data_map, key);
     if (entry_it != kh_end(mp->data_map)) {
@@ -126,6 +133,10 @@ void rt_DataMap_insert(rt_DataMap_t *mp, const char *key, rt_Data_t value)
 
 void rt_DataMap_del(rt_DataMap_t *mp, const char *key)
 {
+    if (!rt_Data_isnull(mp->one_time_lock)) {
+        rt_throw("map is locked from modification with lock id %p", (void*) mp->one_time_lock.data.i64);
+    }
+
     khiter_t entry_it = kh_get(rt_DataMap_t, mp->data_map, key);
     if (entry_it == kh_end(mp->data_map)) rt_throw("map has no key '%s'", key);
     rt_Data_destroy(&kh_value(mp->data_map, entry_it).value);
@@ -134,8 +145,12 @@ void rt_DataMap_del(rt_DataMap_t *mp, const char *key)
     --mp->length;
 }
 
-void rt_DataMap_concat(const rt_DataMap_t *mp1, const rt_DataMap_t *mp2)
+void rt_DataMap_concat(rt_DataMap_t *mp1, const rt_DataMap_t *mp2)
 {
+    if (!rt_Data_isnull(mp1->one_time_lock)) {
+        rt_throw("map is locked from modification with lock id %p", (void*) mp1->one_time_lock.data.i64);
+    }
+
     for (khiter_t entry_it = kh_begin(mp2->data_map); entry_it != kh_end(mp2->data_map); ++entry_it) {
         if (!kh_exist(mp2->data_map, entry_it)) continue;
         const char *key = kh_key(mp2->data_map, entry_it);
@@ -217,6 +232,11 @@ char *rt_DataMap_tostr(const rt_DataMap_t *mp)
     }
     sprintf(&str[p++], "}");
     return str;
+}
+
+void rt_DataMap_lockonce(rt_DataMap_t *mp, int64_t lockid)
+{
+    mp->one_time_lock = rt_Data_i64(lockid);
 }
 
 rt_DataMap_iter_t rt_DataMap_begin(rt_DataMap_t *mp)

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -35,6 +35,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
     }
     if (!strcmp(module, "io")) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;
+        if (!strcmp(fname, "println"))  return rt_fn_IO_PRINTLN;
         if (!strcmp(fname, "input"))    return rt_fn_IO_INPUT;
         if (!strcmp(fname, "fexists"))  return rt_fn_IO_FEXISTS;
         if (!strcmp(fname, "fread"))    return rt_fn_IO_FREAD;
@@ -155,6 +156,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_DBG_TIMENOW_PARAM: return rt_fn_dbg_timenow_parameterized();
 
         case rt_fn_IO_PRINT:      return rt_fn_io_print();
+        case rt_fn_IO_PRINTLN:    return rt_fn_io_println();
         case rt_fn_IO_INPUT:      return rt_fn_io_input();
         case rt_fn_IO_FEXISTS:    return rt_fn_io_fexists();
         case rt_fn_IO_FREAD:      return rt_fn_io_fread();

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -103,6 +103,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "concat"))   return rt_fn_MAP_CONCAT;
         if (!strcmp(fname, "find"))     return rt_fn_MAP_FIND;
         if (!strcmp(fname, "keys"))     return rt_fn_MAP_KEYS;
+        if (!strcmp(fname, "lockonce")) return rt_fn_MAP_LOCKONCE;
     }
 
     if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
@@ -214,6 +215,7 @@ rt_Data_t rt_fn_FunctionsList_call(rt_fn_FunctionDescriptor_t fn)
         case rt_fn_MAP_CONCAT:    return rt_fn_map_concat();
         case rt_fn_MAP_FIND:      return rt_fn_map_find();
         case rt_fn_MAP_KEYS:      return rt_fn_map_keys();
+        case rt_fn_MAP_LOCKONCE:  return rt_fn_map_lockonce();
 
         case rt_fn_DBG_RTSIZE:
         case rt_fn_UNDEFINED:

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -65,6 +65,22 @@ rt_Data_t rt_fn_io_print()
     return rt_Data_i64(bytes);
 }
 
+rt_Data_t rt_fn_io_println()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(0);
+
+    rt_Data_t bytes = rt_fn_call_handler(
+        rt_Data_null(),
+        "io", "print",
+        /* since we are not taking ownership of args, we can
+         * explicitly cast it to non-const to avoid compiler warning
+         */
+        (rt_DataList_t *) args
+    );
+
+    return rt_Data_i64(bytes.data.i64 + printf("\n"));
+}
+
 rt_Data_t rt_fn_io_input()
 {
     const rt_DataList_t *args = rt_fn_get_valid_args(2);

--- a/src/runtime/functions/module_io.c.h
+++ b/src/runtime/functions/module_io.c.h
@@ -278,7 +278,7 @@ rt_Data_t rt_fn_io_libopen()
 {
     const rt_DataList_t *args = rt_fn_get_valid_args(1);
     const rt_Data_t libname_arg = *rt_DataList_getref(args, 0);
-    rt_Data_assert_type(libname_arg, rt_DATA_TYPE_STR, "filename");
+    rt_Data_assert_type(libname_arg, rt_DATA_TYPE_STR, "arg 0");
     char *filename = rt_Data_tostr(libname_arg);
     rt_DataLibHandle_t *handle = rt_DataLibHandle_init(filename);
     return rt_Data_libhandle(handle);
@@ -292,8 +292,8 @@ rt_Data_t rt_fn_io_libsym()
     const rt_Data_t symbolname_arg = *rt_DataList_getref(args, 1);
 
     // Assert that the arguments are of the correct type.
-    rt_Data_assert_type(handle_arg, rt_DATA_TYPE_LIBHANDLE, "handle");
-    rt_Data_assert_type(symbolname_arg, rt_DATA_TYPE_STR, "symbolname");
+    rt_Data_assert_type(handle_arg, rt_DATA_TYPE_LIBHANDLE, "arg 0");
+    rt_Data_assert_type(symbolname_arg, rt_DATA_TYPE_STR, "arg 1");
 
     // Convert the symbol name to a C string.
     char *symbolname = rt_Data_tostr(symbolname_arg);

--- a/src/runtime/functions/module_map.c.h
+++ b/src/runtime/functions/module_map.c.h
@@ -1,12 +1,15 @@
 #ifndef RT_FN_MODULE_MAP_C_H
 #define RT_FN_MODULE_MAP_C_H
 
+#include <inttypes.h>
+
 #include "runtime/data/Data.h"
 #include "runtime/data/DataStr.h"
 #include "runtime/data/DataList.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/functions.h"
 #include "runtime/functions/module_map.h"
+#include "runtime/io.h"
 
 rt_Data_t rt_fn_map_get()
 {
@@ -121,6 +124,10 @@ rt_Data_t rt_fn_map_lockonce()
 
     const rt_Data_t lockid = *rt_DataList_getref(args, 1);
     rt_Data_assert_type(lockid, rt_DATA_TYPE_I64, "arg 1");
+
+    if (lockid.data.i64 == rt_DATA_MAP_LOCKID_RESERVED) {
+        rt_throw("cannot use reserved lock id 0x%" PRIXPTR, (uintptr_t) rt_DATA_MAP_LOCKID_RESERVED);
+    }
 
     rt_DataMap_lockonce(data.data.mp, lockid.data.i64);
 

--- a/src/runtime/functions/module_map.c.h
+++ b/src/runtime/functions/module_map.c.h
@@ -112,6 +112,21 @@ rt_Data_t rt_fn_map_keys()
     return rt_Data_list(keys);
 }
 
+rt_Data_t rt_fn_map_lockonce()
+{
+    const rt_DataList_t *args = rt_fn_get_valid_args(2);
+
+    const rt_Data_t data = *rt_DataList_getref(args, 0);
+    rt_Data_assert_type(data, rt_DATA_TYPE_MAP, "arg 0");
+
+    const rt_Data_t lockid = *rt_DataList_getref(args, 1);
+    rt_Data_assert_type(lockid, rt_DATA_TYPE_I64, "arg 1");
+
+    rt_DataMap_lockonce(data.data.mp, lockid.data.i64);
+
+    return data;
+}
+
 #else
     #warning re-inclusion of module 'functions/module_map.c.h'
 #endif

--- a/src/runtime/functions/nomodule.c.h
+++ b/src/runtime/functions/nomodule.c.h
@@ -35,31 +35,32 @@ rt_Data_t rt_fn_type()
     const rt_Data_t data = *rt_DataList_getref(args, 0);
     switch (data.type) {
         case rt_DATA_TYPE_BUL:
-            return rt_VarTable_typeid_bul;
+            return rt_Data_i64(rt_DATA_TYPE_BUL);
         case rt_DATA_TYPE_CHR:
-            return rt_VarTable_typeid_chr;
+            return rt_Data_i64(rt_DATA_TYPE_CHR);
         case rt_DATA_TYPE_I64:
-            return rt_VarTable_typeid_i64;
+            return rt_Data_i64(rt_DATA_TYPE_I64);
         case rt_DATA_TYPE_F64:
-            return rt_VarTable_typeid_f64;
+            return rt_Data_i64(rt_DATA_TYPE_F64);
         case rt_DATA_TYPE_STR:
+            return rt_Data_i64(rt_DATA_TYPE_STR);
         case rt_DATA_TYPE_INTERP_STR:
-            return rt_VarTable_typeid_str;
+            return rt_Data_i64(rt_DATA_TYPE_INTERP_STR);
         case rt_DATA_TYPE_LST:
-            return rt_VarTable_typeid_lst;
+            return rt_Data_i64(rt_DATA_TYPE_LST);
         case rt_DATA_TYPE_MAP:
-            return rt_VarTable_typeid_map;
+            return rt_Data_i64(rt_DATA_TYPE_MAP);
         case rt_DATA_TYPE_PROC:
-            return rt_VarTable_typeid_proc;
+            return rt_Data_i64(rt_DATA_TYPE_PROC);
         case rt_DATA_TYPE_LAMBDA:
-            return rt_VarTable_typeid_lambda;
+            return rt_Data_i64(rt_DATA_TYPE_LAMBDA);
         case rt_DATA_TYPE_LIBHANDLE:
-            return rt_VarTable_typeid_libhandle;
+            return rt_Data_i64(rt_DATA_TYPE_LIBHANDLE);
         case rt_DATA_TYPE_ANY:
             return rt_Data_isnull(data) ?
-                rt_VarTable_rsv_null : rt_VarTable_typeid_any;
+                rt_VarTable_rsv_null : rt_Data_i64(rt_DATA_TYPE_ANY);
     }
-    return rt_VarTable_typeid_any;
+    return rt_Data_i64(rt_DATA_TYPE_ANY);
 }
 
 rt_Data_t rt_fn_cast()

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -28,8 +28,7 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     rt_Data_t context = rt_Data_null();
 
     if (lhs->type == rt_DATA_TYPE_LAMBDA) {
-        /* TODO: lambda contexts */
-        context = rt_Data_null();
+        context = *lhs->data.lambda.context;
     } else if (lhs->type == rt_DATA_TYPE_PROC && lhs->data.proc.context) {
         context = *lhs->data.proc.context;
     }

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -27,7 +27,7 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     /* context for lambda or procedure */
     rt_Data_t context = rt_Data_null();
 
-    if (lhs->type == rt_DATA_TYPE_LAMBDA) {
+    if (lhs->type == rt_DATA_TYPE_LAMBDA && lhs->data.lambda.context) {
         context = *lhs->data.lambda.context;
     } else if (lhs->type == rt_DATA_TYPE_PROC && lhs->data.proc.context) {
         context = *lhs->data.proc.context;

--- a/tests/SyntaxTree.json
+++ b/tests/SyntaxTree.json
@@ -358,14 +358,18 @@
                       },
                       {
                         "node": "expression",
-                        "op": "NOP",
+                        "op": ".",
                         "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
                           "node": "identifier",
-                          "identifier_name": "i64"
+                          "identifier_name": "Types"
                         },
-                        "rhs_type": "EXPR_TYPE_NULL",
-                        "rhs": null,
+                        "rhs_type": "EXPR_TYPE_LITERAL",
+                        "rhs": {
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "I64"
+                        },
                         "condition_type": "EXPR_TYPE_NULL",
                         "condition": null
                       }
@@ -832,14 +836,18 @@
                         },
                         {
                           "node": "expression",
-                          "op": "NOP",
+                          "op": ".",
                           "lhs_type": "EXPR_TYPE_IDENTIFIER",
                           "lhs": {
                             "node": "identifier",
-                            "identifier_name": "str"
+                            "identifier_name": "Types"
                           },
-                          "rhs_type": "EXPR_TYPE_NULL",
-                          "rhs": null,
+                          "rhs_type": "EXPR_TYPE_LITERAL",
+                          "rhs": {
+                            "node": "literal",
+                            "type": "DATA_TYPE_STR",
+                            "data": "STR"
+                          },
                           "condition_type": "EXPR_TYPE_NULL",
                           "condition": null
                         }
@@ -1292,14 +1300,18 @@
                               },
                               {
                                 "node": "expression",
-                                "op": "NOP",
+                                "op": ".",
                                 "lhs_type": "EXPR_TYPE_IDENTIFIER",
                                 "lhs": {
                                   "node": "identifier",
-                                  "identifier_name": "str"
+                                  "identifier_name": "Types"
                                 },
-                                "rhs_type": "EXPR_TYPE_NULL",
-                                "rhs": null,
+                                "rhs_type": "EXPR_TYPE_LITERAL",
+                                "rhs": {
+                                  "node": "literal",
+                                  "type": "DATA_TYPE_STR",
+                                  "data": "STR"
+                                },
                                 "condition_type": "EXPR_TYPE_NULL",
                                 "condition": null
                               }

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -3,7 +3,7 @@ module main
 proc xyz()
     io:print("Hello world!", lf)
 
-    var x = io:input("", i64)
+    var x = io:input("", Types.I64)
 
     if x == 1 then
         io:print("entered 1", lf)
@@ -18,7 +18,7 @@ proc xyz()
         x = x - 1
     end
 
-    x = io:input("prompt: ", str)
+    x = io:input("prompt: ", Types.STR)
     io:print(f"entered {x}", lf)
 
     # test bool


### PR DESCRIPTION
#### Major API Changes in v2.0 Beta

This release introduces breaking changes and drops all support for `v1.x`

- bugfix: lambda contexts were always getting set to null
- group type variables into `Types` global map
- added `globals` global map for storing global data
- memory managed for global maps
- added map lock to prevent addition or removal of map keys
- locked `Types` and `globals`
- system locked objects use the lock ID `0xDEAF`
- refactor: 1st arg of `rt_DataMap_contact` is no longer const
- added `map:lockonce` to runtime
- updated docs
- bumped to `v2.0 Beta`
