### PR TITLE
v1.6 beta: patched lambda contex bug

### DIFF
--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -28,8 +28,7 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     rt_Data_t context = rt_Data_null();
 
     if (lhs->type == rt_DATA_TYPE_LAMBDA) {
-        /* TODO: lambda contexts */
-        context = rt_Data_null();
+        context = *lhs->data.lambda.context;
     } else if (lhs->type == rt_DATA_TYPE_PROC && lhs->data.proc.context) {
         context = *lhs->data.proc.context;
     }

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -27,7 +27,7 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     /* context for lambda or procedure */
     rt_Data_t context = rt_Data_null();
 
-    if (lhs->type == rt_DATA_TYPE_LAMBDA) {
+    if (lhs->type == rt_DATA_TYPE_LAMBDA && lhs->data.lambda.context) {
         context = *lhs->data.lambda.context;
     } else if (lhs->type == rt_DATA_TYPE_PROC && lhs->data.proc.context) {
         context = *lhs->data.proc.context;


### PR DESCRIPTION
- **update tokop_fncall.c.h to handle lambda contexts**
- **update: check null before setting lambda context to prevent null dereference**
