### PR TITLE
v2.3 beta: bug fixes to module name resolution

### DIFF
--- a/examples/lambdatest/listfile
+++ b/examples/lambdatest/listfile
@@ -1,0 +1,2 @@
+examples/lambdatest/takeslambda.shsc
+examples/lambdatest/main.shsc

--- a/examples/lambdatest/main.shsc
+++ b/examples/lambdatest/main.shsc
@@ -1,0 +1,7 @@
+proc main()
+    var lambda = proc (a, b) {
+        io:println("main:main:(anonymous)", dbg:filename())
+        return a + b
+    }
+    takeslambda:take(lambda)
+end

--- a/examples/lambdatest/takeslambda.shsc
+++ b/examples/lambdatest/takeslambda.shsc
@@ -1,0 +1,12 @@
+module takeslambda
+
+proc take(lambda)
+    return deep_take(lambda)
+end
+
+proc deep_take(lambda)
+    assert:type(lambda, Types.LAMBDA)
+    io:println("takeslambda:deep_take", dbg:filename())
+    return lambda(1, 2)
+end
+    

--- a/include/ast/util/ModuleAndProcTable.h
+++ b/include/ast/util/ModuleAndProcTable.h
@@ -80,6 +80,9 @@ extern ast_util_ModuleAndProcTable_t ast_util_mptable;
 
 bool ast_util_ModuleAndProcTable_empty(void);
 
+/** insert an empty module */
+void ast_util_ModuleAndProcTable_addmodule(const ast_Identifier_t *module_name);
+
 /** Maps ( module_name, proc_name ) -> code */
 void ast_util_ModuleAndProcTable_add(
     const ast_Identifier_t *module_name,
@@ -96,6 +99,9 @@ const ast_FnArgsList_t *ast_util_ModuleAndProcTable_get_args(const ast_Identifie
 
 /** Get filename by a module and a procedure name */
 const char *ast_util_ModuleAndProcTable_get_filename(const ast_Identifier_t *module_name, const ast_Identifier_t *proc_name);
+
+/** Check if a module is defined */
+bool ast_util_ModuleAndProcTable_hasmodule(const ast_Identifier_t *module_name);
 
 /** Check if a module and a procedure name is defined */
 bool ast_util_ModuleAndProcTable_exists(const ast_Identifier_t *module_name, const ast_Identifier_t *proc_name);

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -15,6 +15,8 @@
 #include "runtime/functions/module_str.h"
 #include "runtime/functions/nomodule.h"
 
+extern bool rt_fn_init_inbuilt_modules;
+
 /* define module names */
 #define RT_FN_MODULE_SYS     "sys"
 #define RT_FN_MODULE_ASSERT  "assert"

--- a/include/runtime/functions.h
+++ b/include/runtime/functions.h
@@ -15,6 +15,20 @@
 #include "runtime/functions/module_str.h"
 #include "runtime/functions/nomodule.h"
 
+/* define module names */
+#define RT_FN_MODULE_SYS     "sys"
+#define RT_FN_MODULE_ASSERT  "assert"
+#define RT_FN_MODULE_CHR     "chr"
+#define RT_FN_MODULE_DBG     "dbg"
+#define RT_FN_MODULE_F64     "f64"
+#define RT_FN_MODULE_I64     "i64"
+#define RT_FN_MODULE_IO      "io"
+#define RT_FN_MODULE_IT      "it"
+#define RT_FN_MODULE_STR     "str"
+#define RT_FN_MODULE_LST     "lst"
+#define RT_FN_MODULE_MAP     "map"
+#define RT_FN_MODULE_NOMOD   ""
+
 /**
  rt_fn_<module>_FUNCTION
  for example, if the function descriptor is rt_fn_DBG_REFCNT then

--- a/src/ast/util/ModuleAndProcTable.c.h
+++ b/src/ast/util/ModuleAndProcTable.c.h
@@ -10,6 +10,7 @@
 #ifndef AST_UTIL_MODULE_AND_PROC_TABLE_C_H
 #define AST_UTIL_MODULE_AND_PROC_TABLE_C_H
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -38,6 +39,18 @@ void ast_util_ModuleAndProcTable_create(void)
 bool ast_util_ModuleAndProcTable_empty(void)
 {
     return !ast_util_mptable;
+}
+
+void ast_util_ModuleAndProcTable_addmodule(const ast_Identifier_t *module_name)
+{
+    if (!module_name)
+        io_errndie("ast_util_ModuleAndProcTable_addmodule:" ERR_MSG_NULLPTR " for `module_name`");
+    if (!ast_util_mptable) ast_util_ModuleAndProcTable_create();
+    int ret;
+    char *key = strdup(module_name);
+    khint_t k = kh_put(ast_module_t, ast_util_mptable, key, &ret);
+    kh_value(ast_util_mptable, k).module_name = key;
+    kh_value(ast_util_mptable, k).procmap = kh_init(ast_procedure_t);
 }
 
 /** Maps ( module_name, proc_name ) -> code */
@@ -134,6 +147,14 @@ const char *ast_util_ModuleAndProcTable_get_filename(const ast_Identifier_t *mod
 {
     const ast_util_ModuleAndProcTable_procedure_t proc = ast_util_ModuleAndProcTable_get(module_name, proc_name);
     return proc.src_filename;
+}
+
+/** Check if a module is defined */
+bool ast_util_ModuleAndProcTable_hasmodule(const ast_Identifier_t *module_name)
+{
+    if (!ast_util_mptable) return false;
+    khint_t k = kh_get(ast_module_t, ast_util_mptable, module_name);
+    return k != kh_end(ast_util_mptable);
 }
 
 bool ast_util_ModuleAndProcTable_exists(const ast_Identifier_t *module_name, const ast_Identifier_t *proc_name)

--- a/src/ast/util/ModuleAndProcTable.c.h
+++ b/src/ast/util/ModuleAndProcTable.c.h
@@ -23,6 +23,7 @@
 #include "globals.h"
 #include "io.h"
 #include "parser.h"
+#include "runtime/functions.h"
 #include "runtime/io.h"
 #include "tlib/khash/khash.h"
 
@@ -34,6 +35,23 @@ void ast_util_ModuleAndProcTable_create(void)
 {
     if (ast_util_mptable) return;
     ast_util_mptable = kh_init(ast_module_t);
+
+    /* add inbuilt modules */
+    if (!rt_fn_init_inbuilt_modules) {
+        rt_fn_init_inbuilt_modules = true;
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_SYS);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_ASSERT);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_DBG);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IO);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IT);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_CHR);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_I64);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_F64);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_STR);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_LST);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_MAP);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_NOMOD);
+    }
 }
 
 bool ast_util_ModuleAndProcTable_empty(void)

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -5,31 +5,35 @@
 
 #include "ast.h"
 #include "ast/api.h"
+#include "ast/util/ModuleAndProcTable.h"
 #include "io.h"
 #include "runtime/data/Data.h"
 #include "runtime/data/DataList.h"
 #include "runtime/eval.h"
 #include "runtime/functions.h"
 #include "runtime/io.h"
+#include "runtime/VarTable.h"
+
+bool rt_fn_init_inbuilt_modules = false;
 
 rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const char *fname)
 {
     /* if module matched but procedure didn't match, it should cascade down.
        this is done so that if all matches fail, you can still match the procedures
        that don't have a module name */
-    if (!strcmp(module, "sys")) {
+    if (!strcmp(module, RT_FN_MODULE_SYS)) {
         if (!strcmp(fname, "exit"))     return rt_fn_SYS_EXIT;
         if (!strcmp(fname, "sleep"))    return rt_fn_SYS_SLEEP;
         if (!strcmp(fname, "getenv"))   return rt_fn_SYS_GETENV;
         if (!strcmp(fname, "platform")) return rt_fn_SYS_PLATFORM;
         if (!strcmp(fname, "system"))   return rt_fn_SYS_SYSTEM;
     }
-    if (!strcmp(module, "assert")) {
+    if (!strcmp(module, RT_FN_MODULE_ASSERT)) {
         if (!strcmp(fname, "type"))     return rt_fn_ASSERT_TYPE;
         if (!strcmp(fname, "equals"))   return rt_fn_ASSERT_EQUALS;
         if (!strcmp(fname, "notnull"))  return rt_fn_ASSERT_NOTNULL;
     }
-    if (!strcmp(module, "dbg")) {
+    if (!strcmp(module, RT_FN_MODULE_DBG)) {
         if (!strcmp(fname, "typename")) return rt_fn_DBG_TYPENAME;
         if (!strcmp(fname, "rtsize"))   return rt_fn_DBG_RTSIZE;
         if (!strcmp(fname, "refcnt"))   return rt_fn_DBG_REFCNT;
@@ -40,7 +44,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "timenow"))  return rt_fn_DBG_TIMENOW;
         if (!strcmp(fname, "timenow_param")) return rt_fn_DBG_TIMENOW_PARAM;
     }
-    if (!strcmp(module, "io")) {
+    if (!strcmp(module, RT_FN_MODULE_IO)) {
         if (!strcmp(fname, "print"))    return rt_fn_IO_PRINT;
         if (!strcmp(fname, "println"))  return rt_fn_IO_PRINTLN;
         if (!strcmp(fname, "input"))    return rt_fn_IO_INPUT;
@@ -51,11 +55,11 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "libopen"))  return rt_fn_IO_LIBOPEN;
         if (!strcmp(fname, "libsym"))   return rt_fn_IO_LIBSYM;
     }
-    if (!strcmp(module, "it")) {
+    if (!strcmp(module, RT_FN_MODULE_IT)) {
         if (!strcmp(fname, "len"))      return rt_fn_IT_LEN;
         if (!strcmp(fname, "clone"))    return rt_fn_IT_CLONE;
     }
-    if (!strcmp(module, "chr")) {
+    if (!strcmp(module, RT_FN_MODULE_CHR)) {
         if (!strcmp(fname, "isdigit"))  return rt_fn_CHR_ISDIGIT;
         if (!strcmp(fname, "isalpha"))  return rt_fn_CHR_ISALPHA;
         if (!strcmp(fname, "isalnum"))  return rt_fn_CHR_ISALNUM;
@@ -65,15 +69,15 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "max"))      return rt_fn_CHR_MAX;
         if (!strcmp(fname, "min"))      return rt_fn_CHR_MIN;
     }
-    if (!strcmp(module, "i64")) {
+    if (!strcmp(module, RT_FN_MODULE_I64)) {
         if (!strcmp(fname, "max"))      return rt_fn_I64_MAX;
         if (!strcmp(fname, "min"))      return rt_fn_I64_MIN;
     }
-    if (!strcmp(module, "f64")) {
+    if (!strcmp(module, RT_FN_MODULE_F64)) {
         if (!strcmp(fname, "max"))      return rt_fn_F64_MAX;
         if (!strcmp(fname, "min"))      return rt_fn_F64_MIN;
     }
-    if (!strcmp(module, "str")) {
+    if (!strcmp(module, RT_FN_MODULE_STR)) {
         if (!strcmp(fname, "equals"))   return rt_fn_STR_EQUALS;
         if (!strcmp(fname, "compare"))  return rt_fn_STR_COMPARE;
         if (!strcmp(fname, "tolower"))  return rt_fn_STR_TOLOWER;
@@ -90,7 +94,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "tof64"))    return rt_fn_STR_TOF64;
         if (!strcmp(fname, "sort"))     return rt_fn_STR_SORT;
     }
-    if (!strcmp(module, "lst")) {
+    if (!strcmp(module, RT_FN_MODULE_LST)) {
         if (!strcmp(fname, "equals"))   return rt_fn_LST_EQUALS;
         if (!strcmp(fname, "compare"))  return rt_fn_LST_COMPARE;
         if (!strcmp(fname, "append"))   return rt_fn_LST_APPEND;
@@ -104,7 +108,7 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "sort"))     return rt_fn_LST_SORT;
     }
 
-    if (!strcmp(module, "map")) {
+    if (!strcmp(module, RT_FN_MODULE_MAP)) {
         if (!strcmp(fname, "set"))      return rt_fn_MAP_SET;
         if (!strcmp(fname, "get"))      return rt_fn_MAP_GET;
         if (!strcmp(fname, "erase"))    return rt_fn_MAP_ERASE;

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -273,23 +273,6 @@ rt_Data_t rt_fn_call_handler(
     const char *proc_name,
     rt_DataList_t *args
 ) {
-
-    if (!rt_fn_init_inbuilt_modules) {
-        rt_fn_init_inbuilt_modules = true;
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_SYS);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_ASSERT);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_DBG);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IO);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IT);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_CHR);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_I64);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_F64);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_STR);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_LST);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_MAP);
-        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_NOMOD);
-    }
-
     const ast_Identifier_t *module = (const ast_Identifier_t*) module_name;
     const ast_Identifier_t *proc = (const ast_Identifier_t*) proc_name;
 

--- a/src/runtime/functions.c.h
+++ b/src/runtime/functions.c.h
@@ -118,14 +118,17 @@ rt_fn_FunctionDescriptor_t rt_fn_FunctionsList_getfn(const char *module, const c
         if (!strcmp(fname, "lockonce")) return rt_fn_MAP_LOCKONCE;
     }
 
-    if (!strcmp(fname, "isnull"))       return rt_fn_ISNULL;
-    if (!strcmp(fname, "tostr"))        return rt_fn_TOSTR;
-    if (!strcmp(fname, "type"))         return rt_fn_TYPE;
-    if (!strcmp(fname, "cast"))         return rt_fn_CAST;
-    if (!strcmp(fname, "errndie"))      return rt_fn_ERRNDIE;
-    if (!strcmp(fname, "max"))          return rt_fn_MAX;
-    if (!strcmp(fname, "min"))          return rt_fn_MIN;
-    if (!strcmp(fname, "rand"))         return rt_fn_RAND;
+    if (!strcmp(module, rt_VarTable_top_proc()->module_name)
+     || !strcmp(module, RT_FN_MODULE_NOMOD)) {
+        if (!strcmp(fname, "isnull"))   return rt_fn_ISNULL;
+        if (!strcmp(fname, "tostr"))    return rt_fn_TOSTR;
+        if (!strcmp(fname, "type"))     return rt_fn_TYPE;
+        if (!strcmp(fname, "cast"))     return rt_fn_CAST;
+        if (!strcmp(fname, "errndie"))  return rt_fn_ERRNDIE;
+        if (!strcmp(fname, "max"))      return rt_fn_MAX;
+        if (!strcmp(fname, "min"))      return rt_fn_MIN;
+        if (!strcmp(fname, "rand"))     return rt_fn_RAND;
+    }
 
     return rt_fn_UNDEFINED;
 }
@@ -270,6 +273,23 @@ rt_Data_t rt_fn_call_handler(
     const char *proc_name,
     rt_DataList_t *args
 ) {
+
+    if (!rt_fn_init_inbuilt_modules) {
+        rt_fn_init_inbuilt_modules = true;
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_SYS);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_ASSERT);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_DBG);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IO);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_IT);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_CHR);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_I64);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_F64);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_STR);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_LST);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_MAP);
+        ast_util_ModuleAndProcTable_addmodule(RT_FN_MODULE_NOMOD);
+    }
+
     const ast_Identifier_t *module = (const ast_Identifier_t*) module_name;
     const ast_Identifier_t *proc = (const ast_Identifier_t*) proc_name;
 

--- a/src/runtime/operators/dcolon.c.h
+++ b/src/runtime/operators/dcolon.c.h
@@ -3,6 +3,7 @@
 
 #include "ast.h"
 #include "ast/api.h"
+#include "ast/util/ModuleAndProcTable.h"
 #include "runtime/data/Data.h"
 #include "runtime/data/DataMap.h"
 #include "runtime/io.h"
@@ -14,6 +15,9 @@ void rt_op_dcolon(const ast_Expression_t *expr)
     if (expr->lhs_type != EXPR_TYPE_IDENTIFIER
         || expr->rhs_type != EXPR_TYPE_IDENTIFIER)
             rt_throw("invalid use of module membership operator");
+    /* check if the module exists */
+    if (!ast_util_ModuleAndProcTable_hasmodule(expr->lhs.variable))
+        rt_throw("undefined module '%s'", expr->lhs.variable);
     /* instead of evaluating the LHS and RHS, directly generate a
        procedure type literal and return it via accumulator */
     rt_VarTable_acc_setval(rt_Data_proc(

--- a/src/runtime/util/libloader.c.h
+++ b/src/runtime/util/libloader.c.h
@@ -34,6 +34,8 @@ void rt_util_libloader(void *handle) {
         rt_Data_any,
         rt_Data_null,
         rt_Data_clone,
+        rt_Data_increfc,
+        rt_Data_decrefc,
         rt_Data_destroy,
         rt_Data_isnull,
         rt_Data_isnumeric,

--- a/tests/SyntaxTree.json
+++ b/tests/SyntaxTree.json
@@ -1,5 +1,38 @@
 {
   "node": "root",
+  "": {
+    "node": "module"
+  },
+  "f64": {
+    "node": "module"
+  },
+  "assert": {
+    "node": "module"
+  },
+  "io": {
+    "node": "module"
+  },
+  "i64": {
+    "node": "module"
+  },
+  "dbg": {
+    "node": "module"
+  },
+  "it": {
+    "node": "module"
+  },
+  "lst": {
+    "node": "module"
+  },
+  "chr": {
+    "node": "module"
+  },
+  "sys": {
+    "node": "module"
+  },
+  "str": {
+    "node": "module"
+  },
   "inher:Derived": {
     "node": "module",
     "init": {
@@ -1068,5 +1101,8 @@
         ]
       }
     }
+  },
+  "map": {
+    "node": "module"
   }
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -59,23 +59,7 @@ make run-sanitize ARGS="$testpath/inheritance/*.shsc -args 123 abc 1 2 3"
 testpath="$(cd "$(dirname "$0")" && pwd)/../tests"
 testpath="$(realpath "$testpath")"
 
-
-echo -e "\n-----------------------------------------------------\n"
-echo -e ">> Bulk running using examples/inheritance/listfile\n"
-# flag -tf test
-# run make run-sanitize ARGS="-tf tests/SyntaxTree.json -r examples/inheritance/listfile"
-# test fails if theres a difference between old and new SyntaxTree.json
-# this can be checked with git
-make run-sanitize ARGS="-tf tests/SyntaxTree.json -r examples/inheritance/listfile -args 123 abc 1 2 3"
-
-# check if there are any differences between old and new SyntaxTree.json
-# if there are differences, the test fails
-if ! git diff --quiet --exit-code tests/SyntaxTree.json; then
-    echo 'test.sh: error: SyntaxTree.json has changed.' >&2
-    exit 1
-fi
-
-# finally, test the eaxmple at submodule lib/libshsc
+# test the eaxmple at submodule lib/libshsc
 echo -e "\n-----------------------------------------------------\n"
 echo -e ">> Running lib/libshsc/examples/add.shsc\n"
 
@@ -97,3 +81,18 @@ fi
 ../../target/shsc-dbg examples/add.shsc
 rm -f examples/add.so examples/add.dylib examples/add.dll
 cd ../../
+
+# flag -tf test
+echo -e "\n-----------------------------------------------------\n"
+echo -e ">> Bulk running using examples/inheritance/listfile\n"
+# run make run-sanitize ARGS="-tf tests/SyntaxTree.json -r examples/inheritance/listfile"
+# test fails if theres a difference between old and new SyntaxTree.json
+# this can be checked with git
+make run-sanitize ARGS="-tf tests/SyntaxTree.json -r examples/inheritance/listfile -args 123 abc 1 2 3"
+
+# check if there are any differences between old and new SyntaxTree.json
+# if there are differences, the test fails
+if ! git diff --quiet --exit-code tests/SyntaxTree.json; then
+    echo 'test.sh: error: SyntaxTree.json has changed.' >&2
+    exit 1
+fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -74,3 +74,26 @@ if ! git diff --quiet --exit-code tests/SyntaxTree.json; then
     echo 'test.sh: error: SyntaxTree.json has changed.' >&2
     exit 1
 fi
+
+# finally, test the eaxmple at submodule lib/libshsc
+echo -e "\n-----------------------------------------------------\n"
+echo -e ">> Running lib/libshsc/examples/add.shsc\n"
+
+# if pwd base is tests/, go up one level
+if [[ "$PWD" == *tests ]]; then
+    cd ..
+fi
+
+cd lib/libshsc
+make cleaner; make dbg
+
+# choose extension based on platform
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    gcc -Iinclude -shared -fPIC -o examples/add.so examples/add.c -Ltarget -lshsc-dbg
+elif [[ "$OSTYPE" == "msys" ]]; then
+    gcc -Iinclude -shared -fPIC -o examples/add.dll examples/add.c -Ltarget -lshsc-dbg
+fi
+
+../../target/shsc-dbg examples/add.shsc
+rm -f examples/add.so examples/add.dylib examples/add.dll
+cd ../../


### PR DESCRIPTION
- **add function to insert an empty module and check if module exists in ModuleAndProcTable**
- **add module existence check in dcolon.c.h**
- **hold built-in module names as macro constants in functions.h**
- **bug fix: add checks for invalid module name for built-in fn without any module**
- **added test to check filename of lambdas**
- **update submodule commit reference in libshsc**
- **add reference counting for rt_Data objects in libloader.c.h**
- **update submodule commit reference in libshsc**
- **update submodule commit reference in libshsc**
- **added test for c interop**
- **bugfix: create in-built modules immediately after ModuleAndProcTable init**
- **move syntax tree test to last as it exits with error if failed**
- **syntax tree has changed**
