### PR TITLE
v2.3 beta: update: using relative file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ shsc examples/fibonacci.txt
  - List file is specified using the `--run` flag
  - This loads multiple files for execution under a single runtime
  - Each line of the list file has a single shsc file path
- - Paths are relative to working directory of `shsc` command
+ - Paths are relative to directory of list file
  - Spaces in file path is valid and quotes not required
- - If shsc fails to read one file, it'll skip to next file
- - If shsc fails to parse any file, it'll report error and exit
+ - If shsc fails to read or parse any file, it'll report error and exit
 
 #### Example
 The file paths should be relative to the directory where `shsc` will be executed.

--- a/examples/fileio.shsc
+++ b/examples/fileio.shsc
@@ -1,5 +1,5 @@
 proc main()
-    io:print(io:fexists("./compile_flags.txt"), lf)
-    io:print(io:fexists("./src/compile_flags.txt"), lf)
-    io:print(io:fread("compile_flags.txt"), lf)
+    io:print(io:fexists("../compile_flags.txt"), lf)
+    io:print(io:fexists("../src/compile_flags.txt"), lf)
+    io:print(io:fread("../compile_flags.txt"), lf)
 end

--- a/examples/inheritance/listfile
+++ b/examples/inheritance/listfile
@@ -1,3 +1,3 @@
-examples/inheritance/base.shsc
-examples/inheritance/derived.shsc
-examples/inheritance/main.shsc
+base.shsc
+derived.shsc
+main.shsc

--- a/examples/interop_with_c.shsc
+++ b/examples/interop_with_c.shsc
@@ -1,5 +1,5 @@
 proc main()
-    var mod = io:libopen("examples/add")
+    var mod = io:libopen("add")
     var add = io:libsym(mod, "shsc_add")
     var res = add(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     io:print(res, lf)

--- a/examples/lambdatest/listfile
+++ b/examples/lambdatest/listfile
@@ -1,2 +1,2 @@
-examples/lambdatest/takeslambda.shsc
-examples/lambdatest/main.shsc
+takeslambda.shsc
+main.shsc

--- a/examples/oop/listfile
+++ b/examples/oop/listfile
@@ -1,2 +1,2 @@
-examples/oop/ComplexNo.shsc
-examples/oop/main.shsc
+ComplexNo.shsc
+main.shsc

--- a/include/util.h
+++ b/include/util.h
@@ -9,5 +9,7 @@ int util_rand();
 uint64_t util_gettime_ms();
 void util_sleep_ms(int milliseconds);
 int util_system(const char *command, char **outbuff, char **errbuff);
+char *util_sjoin(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+char *util_dirname(const char *path);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -111,8 +111,21 @@ int main(int argc, char **argv)
     if (!strcmp(argv[argv_index], "-r") || !strcmp(argv[argv_index], "--run")) {
         /* check if there is a list file to load the scripts */
         if (argv_index +1 >= argc) io_errnexit("no list file provided for '--run'");
+        /* get lisfile path */
+        const char *listfilepah = argv[++argv_index];
+        /* get listfile dirname */
+        char *listfiledir = util_dirname(listfilepah);
         /* read the list file */
-        filepaths = io_read_lines(argv[++argv_index], &file_cnt);
+        filepaths = io_read_lines(listfilepah, &file_cnt);
+        /* to each line read, prepend listfiledir
+           this makes all files relative to listfiledir */
+        for (size_t i = 0; i < file_cnt; ++i) {
+            char *newpath = util_sjoin("%s/%s", listfiledir, filepaths[i]);
+            free(filepaths[i]);
+            filepaths[i] = newpath;
+        }
+        /* free listfiledir */
+        free(listfiledir);
         /* set flag to deallocate filepaths */
         from_listfile = true;
         /* go to next argument; --run can work alone */

--- a/src/runtime/io.c.h
+++ b/src/runtime/io.c.h
@@ -16,11 +16,12 @@
 #define RT_IO_THROW_DONT_PRINT_FN ""
 
 #define RT_THROW_EXITCODE(fmt, args) do {                                   \
-    fprintf(stderr, "shsc: " RT_IO_THROW_DONT_PRINT_FN "%s:%d: ",           \
+    fprintf(stderr, "shsc: " RT_IO_THROW_DONT_PRINT_FN ""                   \
         /* rt_VarTable_top_proc()->module_name, */                          \
         /* rt_VarTable_top_proc()->proc_name, */                            \
-        rt_VarTable_top_proc()->filepath,                                   \
-        rt_VarTable_top_proc()->current_line);                              \
+        /* rt_VarTable_top_proc()->filepath,  */                            \
+        /* rt_VarTable_top_proc()->current_line */                          \
+    );                                                                      \
     fflush(stderr);                                                         \
     va_start(args, fmt);                                                    \
     vfprintf(stderr, fmt, args);                                            \

--- a/src/util.c
+++ b/src/util.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -116,4 +117,30 @@ int util_system(const char *command, char **outbuff, char **errbuff)
 
     free(cmdbuffer);
     return ret;
+}
+
+char *util_sjoin(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    size_t len = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+    char *buffer = malloc(len + 1);
+    if (!buffer) {
+        io_errndie("util_sjoin: couldn't allocate memory");
+    }
+    va_start(args, fmt);
+    vsnprintf(buffer, len + 1, fmt, args);
+    va_end(args);
+    return buffer;
+}
+
+char *util_dirname(const char *path)
+{
+    char *buffer = strdup(path);
+    char *last_slash = strrchr(buffer, '/');
+    if (last_slash) {
+        *last_slash = '\0';
+    }
+    return buffer;
 }


### PR DESCRIPTION
- **add util_sjoin and util_dirname utility functions**
- **update API: load shsc scripts relative to the directory of the list file**
- **use dir path relative to script file for file operations in module_io.c.h**
- **use relative file paths in examples**
- **update submodule commit reference in libshsc**
- **update to error msg: filename is not printed in error summary coz stack trace already has that**
