### PR TITLE
v2.4 beta: stack-use-after-free memory bug fix

### DIFF
--- a/examples/lambda3.shsc
+++ b/examples/lambda3.shsc
@@ -1,0 +1,14 @@
+proc main()
+    var list = [1, 2, 3]
+    var res = foo(list).lamb(6)
+    io:println(res)
+end
+
+proc foo(list)
+    var lamb = proc (x) {
+        var newlist = this.list + [x]
+        io:println(newlist)
+        return lst:join(newlist, "")
+    }
+    return { lamb: lamb, list: list }
+end

--- a/include/runtime/data/BoxedData.h
+++ b/include/runtime/data/BoxedData.h
@@ -1,0 +1,36 @@
+#ifndef RT_BOXED_DATA_H
+#define RT_BOXED_DATA_H
+
+#include <stdint.h>
+
+#include "runtime/data/Data.h"
+
+/**
+ * The BoxedData acts like a list of 1 element.
+ * This is used to store a rt_Data_t in the heap.
+ * This is useful when a pointer to rt_Data_t is required.
+ * rt_Data_t is a stack based type i.e. its members are reference
+ * counted but the struct itself is not. So, we cannot maintain a
+ * pointer to an rt_Data_t outside its scope, which means struct
+ * type members inside rt_Data_t like struct rt_DataLambda_t or
+ * struct rt_DataProc_t cannot have a struct rt_Data_t but needs
+ * to have a pointer of rt_Data_t in them.
+ * This has created problems in context of procs and lambdas coz
+ * the rt_Data_t context pointer ends up referring to a stack object
+ * which has already been cleared.
+ * This however only happens if the context data was never stored using
+ * the rt_VarTable_create or rt_VarTable_modf. This is because the
+ * variable table holds data for the entire scope and can return a
+ * rt_Data_t pointer.
+ */
+struct rt_BoxedData_t {
+    int64_t rc;
+    rt_Data_t *data;
+};
+
+rt_BoxedData_t *rt_BoxedData_from(rt_Data_t data);
+void rt_BoxedData_increfc(rt_BoxedData_t *bd);
+void rt_BoxedData_decrefc(rt_BoxedData_t *bd);
+void rt_BoxedData_destroy(rt_BoxedData_t **ptr);
+
+#endif

--- a/include/runtime/data/Data.h
+++ b/include/runtime/data/Data.h
@@ -9,6 +9,7 @@
 #define rt_DATA_LAMBDA_DEFAULT_NAME "(anonymous)"
 
 typedef struct rt_Data_t rt_Data_t;
+typedef struct rt_BoxedData_t rt_BoxedData_t;
 typedef struct rt_DataStr_t rt_DataStr_t;
 typedef struct rt_DataList_t rt_DataList_t;
 typedef struct rt_DataMap_t rt_DataMap_t;
@@ -45,7 +46,7 @@ enum rt_DataType_t {
 struct rt_DataProc_t {
     const ast_Identifier_t *module_name;
     const ast_Identifier_t *proc_name;
-    const rt_Data_t *context;
+    rt_BoxedData_t *context;
 };
 
 enum rt_DataLambdaType_t {
@@ -60,7 +61,7 @@ struct rt_DataNativeFn_t {
 };
 
 struct rt_DataLambda_t {
-    const rt_Data_t *context;
+    rt_BoxedData_t *context;
     union {
         const ast_LambdaLiteral_t *nonnative;
         rt_DataNativeFn_t native;

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ WRN_ERR_FLAGS  := -Wall\
 				  -Wno-unused-but-set-variable\
 				  -Wno-unused-label\
 				  -Wno-int-in-bool-context
-ASAN_FLAGS	 := -fsanitize=address
+ASAN_FLAGS	   := -fsanitize=address
 ASAN_OPTIONS   := ASAN_OPTIONS=detect_leaks=1:$\
 				  fast_unwind_on_malloc=0:$\
 				  strict_init_order=true:$\

--- a/src/runtime/data/BoxedData.c.h
+++ b/src/runtime/data/BoxedData.c.h
@@ -1,0 +1,83 @@
+#ifndef RT_BOXED_DATA_C_H
+#define RT_BOXED_DATA_C_H
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/* -----------------------------------------------------------------------
+            rt_BoxedData_t         rt_Data_t               rt_DataMap_t
+        
+                                 /------------
+           /---------------      |           |           /--------------
+ O-------->|  3  |  data  |----->|  in heap  |---------->|  2  |  ...  |
+           ---------------/      |           |           --------------/
+                 ^   ^           ------------/                  ^
+                 |   |                                          |
+ O---------------/   |           /-------------                 |
+                     |           |            |                 |
+ O-------------------/           |  in stack  |-----------------/
+                                 |            |
+                                 -------------/
+ ---------------------------------------------------------------------- */
+
+#include "runtime/data/Data.h"
+#include "runtime/data/BoxedData.h"
+#include "runtime/VarTable.h"
+
+rt_BoxedData_t *rt_BoxedData_from(rt_Data_t data)
+{
+    rt_BoxedData_t *bd = (rt_BoxedData_t*) malloc(sizeof(rt_BoxedData_t));
+    /* Allocate rt_Data_t in the heap */
+    bd->data = (rt_Data_t*) malloc(sizeof(rt_Data_t));
+    *bd->data = rt_Data_null();
+    bd->rc = 0;
+
+    /* explicitly set lvalue coz modf sets it to false */
+    bd->data->lvalue = true;
+
+    /* Assign data from stack rt_Data_t to the one in heap. rt_VarTable_modf
+       takes care of reference count of the members of the stack rt_Data_t */
+    rt_VarTable_modf(bd->data, data, false, false);
+
+    return bd;
+}
+
+void rt_BoxedData_increfc(rt_BoxedData_t *bd)
+{
+    if (!bd) return;
+    ++bd->rc;
+}
+
+void rt_BoxedData_decrefc(rt_BoxedData_t *bd)
+{
+    if (!bd) return;
+    --bd->rc;
+    if (bd->rc < 0) bd->rc = 0;
+}
+
+void rt_BoxedData_destroy(rt_BoxedData_t **ptr)
+{
+    if (!ptr || !*ptr) return;
+    rt_BoxedData_t *bd = *ptr;
+    rt_BoxedData_decrefc(bd);
+    if (bd->rc > 0) {
+        return;
+    }
+
+    /* explicitly set lvalue coz modf sets it to false */
+    bd->data->lvalue = true;
+
+    /* Set data to null with rt_VarTable_modf, which effective clears the
+       contents (members and their reference counts) */
+    rt_VarTable_modf(bd->data, rt_Data_null(), false, false);
+
+    free(bd->data);
+    bd->data = NULL;
+    free(bd);
+    *ptr = NULL;
+}
+
+#else
+    #warning re-inclusion of module 'runtime/data/BoxedData.c.h'
+#endif

--- a/src/runtime/operators/tokop_fncall.c.h
+++ b/src/runtime/operators/tokop_fncall.c.h
@@ -6,6 +6,7 @@
 #include "io.h"
 #include "runtime.h"
 #include "runtime/data/Data.h"
+#include "runtime/data/BoxedData.h"
 #include "runtime/data/DataList.h"
 #include "runtime/eval.h"
 #include "runtime/functions.h"
@@ -28,9 +29,9 @@ void rt_op_fncall(const rt_Data_t *lhs, const rt_Data_t *rhs) {
     rt_Data_t context = rt_Data_null();
 
     if (lhs->type == rt_DATA_TYPE_LAMBDA && lhs->data.lambda.context) {
-        context = *lhs->data.lambda.context;
+        context = *lhs->data.lambda.context->data;
     } else if (lhs->type == rt_DATA_TYPE_PROC && lhs->data.proc.context) {
-        context = *lhs->data.proc.context;
+        context = *lhs->data.proc.context->data;
     }
 
     /* call the lambda or */


### PR DESCRIPTION
- **add example script demonstrating acessing local data from lambda function returned by a outer fn**
- **add BoxedData structure for heap storage of rt_Data_t with reference counting**
- **refactor: replace rt_Data_t context with rt_BoxedData_t in lambda and proc structures**
- **style: adjust formatting of ASAN_FLAGS in Makefile**
- **chore: update subproject commit reference in libshsc**
